### PR TITLE
Fix soot errors

### DIFF
--- a/SparseBoomerangCorrectness/src/test/java/test/aliasing/AliasingTestSetUp.java
+++ b/SparseBoomerangCorrectness/src/test/java/test/aliasing/AliasingTestSetUp.java
@@ -63,6 +63,7 @@ public class AliasingTestSetUp {
 
     Options.v().set_no_bodies_for_excluded(true);
     Options.v().set_allow_phantom_refs(true);
+    Options.v().setPhaseOption("jb.sils", "enabled:false");
     Options.v().setPhaseOption("jb", "use-original-names:true");
     Options.v().set_prepend_classpath(false);
 

--- a/boomerangScope/src/main/java/boomerang/scene/jimple/JimpleStatement.java
+++ b/boomerangScope/src/main/java/boomerang/scene/jimple/JimpleStatement.java
@@ -495,6 +495,6 @@ public class JimpleStatement extends Statement {
   }
 
   public boolean isUnitializedFieldStatement() {
-    return delegate.hasTag(BoomerangPretransformer.UNITIALIZED_FIELD_TAG_NAME);
+    return delegate.hasTag(BoomerangPretransformer.UNINITIALIZED_FIELD_TAG_NAME);
   }
 }

--- a/testCore/src/main/java/test/core/selfrunning/AbstractTestingFramework.java
+++ b/testCore/src/main/java/test/core/selfrunning/AbstractTestingFramework.java
@@ -105,6 +105,7 @@ public abstract class AbstractTestingFramework {
 
     Options.v().set_include(getIncludeList());
 
+    Options.v().setPhaseOption("jb.sils", "enabled:false");
     Options.v().setPhaseOption("jb", "use-original-names:true");
 
     Options.v().set_exclude(excludedPackages());


### PR DESCRIPTION
Fix the errors that originate from the newest soot version:
- Change the line tags `IDENTIFIER` to `NAME`
- Disable the phase `jb.sils` because it automatically runs phases that violate Boomerang's requirements (this phase was added in Soot 4.3.0 and is enabled by default)
- Fix an error in the BoomerangPretransformer where parameters are not replaced correctly