### PR TITLE
Update actions to run with Java 11

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,14 @@ jobs:
     name: Sparse SPDS deployment 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Sets up Java version
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-package: 'jdk'
-          java-version: '8'
+          java-version: '11'
           server-id: 'ossrh' # must match the serverId configured for the nexus-staging-maven-plugin
           server-username: OSSRH_USERNAME # Env var that holds your OSSRH user name
           server-password: OSSRH_PASSWORD # Env var that holds your OSSRH user pw

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,9 +8,9 @@ jobs:
   BuildAndTest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
       with:
         java-version: 1.8
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,8 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+          distribution: 'adopt'
+          java-package: jdk
+          java-version: '11'
     - name: Build with Maven
       run: mvn -B verify --file pom.xml -P ci

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -47,8 +47,8 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
         </dependency>
     </dependencies>
 

--- a/boomerangScope/src/main/java/boomerang/scene/sparse/SparseCFGBuilder.java
+++ b/boomerangScope/src/main/java/boomerang/scene/sparse/SparseCFGBuilder.java
@@ -95,14 +95,13 @@ public class SparseCFGBuilder {
   protected void removeStmt(MutableGraph<Unit> mCFG, Unit unit) {
     Set<Unit> preds = mCFG.predecessors(unit);
     List<Unit> tmpPreds = new ArrayList<>();
-    preds.forEach(e->tmpPreds.add(e));
+    preds.forEach(e -> tmpPreds.add(e));
     Set<Unit> succs = mCFG.successors(unit);
     List<Unit> tmpSuccs = new ArrayList<>();
-    succs.forEach(e->tmpSuccs.add(e));
+    succs.forEach(e -> tmpSuccs.add(e));
     if (tmpPreds.size() == 1 && tmpSuccs.size() == 1) {
       mCFG.removeNode(unit);
       mCFG.putEdge(tmpPreds.get(0), tmpSuccs.get(0));
     }
   }
-
 }

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-simple</artifactId>
         </dependency>
     </dependencies>
     <profiles>

--- a/idealPDS/src/main/java/typestate/impl/statemachines/VectorStateMachine.java
+++ b/idealPDS/src/main/java/typestate/impl/statemachines/VectorStateMachine.java
@@ -69,6 +69,9 @@ public class VectorStateMachine extends TypeStateMachineWeightFunctions {
             Parameter.This,
             States.NOT_EMPTY,
             Type.OnCall));
+    addTransition(
+        new MatcherTransition(
+            States.NOT_EMPTY, ADD_ELEMENT_METHODS, Parameter.This, States.NOT_EMPTY, Type.OnCall));
 
     addTransition(
         new MatcherTransition(

--- a/idealPDS/src/test/java/typestate/tests/StackTest.java
+++ b/idealPDS/src/test/java/typestate/tests/StackTest.java
@@ -22,7 +22,6 @@ import typestate.impl.statemachines.VectorStateMachine;
 @SuppressWarnings("deprecation")
 public class StackTest extends IDEALTestingFramework {
 
-  @Ignore("Broken since refactoring scope")
   @Test
   public void test1() {
     Stack s = new Stack();

--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,8 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.33</version>
+                <artifactId>slf4j-simple</artifactId>
+                <version>2.0.16</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
-Update actions to run with Java 11 and newest versions in general
-Add a transition in the IDEal test cases to adapt to new Vector implementation in Java 11