### PR TITLE
Fix weight shifts in IDEAL

### DIFF
--- a/boomerangPDS/src/main/java/boomerang/example/ExampleMain2.java
+++ b/boomerangPDS/src/main/java/boomerang/example/ExampleMain2.java
@@ -157,7 +157,7 @@ public class ExampleMain2 {
               solver.solve((ForwardQuery) query);
 
           // 3. Process forward results
-          Table<Edge, Val, NoWeight> results = forwardBoomerangResults.asStatementValWeightTable();
+          Table<Edge, Val, NoWeight> results = forwardBoomerangResults.asEdgeValWeightTable();
           for (Edge s : results.rowKeySet()) {
             // 4. Filter results based on your use statement, in our case the call of
             // System.out.println(n.nested.field)

--- a/boomerangPDS/src/main/java/boomerang/guided/DemandDrivenGuidedAnalysis.java
+++ b/boomerangPDS/src/main/java/boomerang/guided/DemandDrivenGuidedAnalysis.java
@@ -90,7 +90,7 @@ public class DemandDrivenGuidedAnalysis {
         }
 
         Table<Edge, Val, NoWeight> forwardResults =
-            results.asStatementValWeightTable((ForwardQuery) pop.query);
+            results.asEdgeValWeightTable((ForwardQuery) pop.query);
         // Any ForwardQuery may trigger additional ForwardQuery under its own scope.
         triggerNewBackwardQueries(forwardResults, currentQuery, QueryDirection.FORWARD);
       } else {
@@ -103,16 +103,14 @@ public class DemandDrivenGuidedAnalysis {
                   (BackwardQuery) pop.query, pop.triggeringNode, pop.parentQuery);
         }
         Table<Edge, Val, NoWeight> backwardResults =
-            solver.getBackwardSolvers().get(query).asStatementValWeightTable();
+            solver.getBackwardSolvers().get(query).asEdgeValWeightTable();
 
         triggerNewBackwardQueries(backwardResults, pop.query, QueryDirection.BACKWARD);
         Map<ForwardQuery, Context> allocationSites = results.getAllocationSites();
 
         for (Entry<ForwardQuery, Context> entry : allocationSites.entrySet()) {
           triggerNewBackwardQueries(
-              results.asStatementValWeightTable(entry.getKey()),
-              entry.getKey(),
-              QueryDirection.FORWARD);
+              results.asEdgeValWeightTable(entry.getKey()), entry.getKey(), QueryDirection.FORWARD);
         }
       }
     }

--- a/boomerangPDS/src/main/java/boomerang/results/AbstractBoomerangResults.java
+++ b/boomerangPDS/src/main/java/boomerang/results/AbstractBoomerangResults.java
@@ -58,7 +58,11 @@ public class AbstractBoomerangResults<W extends Weight> {
             new OpeningCallStackExtracter<>(initialState, initialState, context, forwardSolver));
   }
 
-  public Table<Edge, Val, W> asStatementValWeightTable(ForwardQuery query) {
+  public Table<Edge, Val, W> asEdgeValWeightTable(ForwardQuery query) {
+    return queryToSolvers.getOrCreate(query).asEdgeValWeightTable();
+  }
+
+  public Table<Statement, Val, W> asStatementValWeightTable(ForwardQuery query) {
     return queryToSolvers.getOrCreate(query).asStatementValWeightTable();
   }
 

--- a/boomerangPDS/src/main/java/boomerang/results/ForwardBoomerangResults.java
+++ b/boomerangPDS/src/main/java/boomerang/results/ForwardBoomerangResults.java
@@ -95,7 +95,7 @@ public class ForwardBoomerangResults<W extends Weight> extends AbstractBoomerang
     if (solver == null) {
       return HashBasedTable.create();
     }
-    Table<Edge, Val, W> res = asStatementValWeightTable();
+    Table<Edge, Val, W> res = asEdgeValWeightTable();
     Set<Method> visitedMethods = Sets.newHashSet();
     for (Edge s : res.rowKeySet()) {
       visitedMethods.add(s.getMethod());
@@ -138,7 +138,11 @@ public class ForwardBoomerangResults<W extends Weight> extends AbstractBoomerang
     return destructingStatement;
   }
 
-  public Table<Edge, Val, W> asStatementValWeightTable() {
+  public Table<Edge, Val, W> asEdgeValWeightTable() {
+    return asEdgeValWeightTable(query);
+  }
+
+  public Table<Statement, Val, W> asStatementValWeightTable() {
     return asStatementValWeightTable(query);
   }
 

--- a/boomerangPDS/src/main/java/boomerang/solver/AbstractBoomerangSolver.java
+++ b/boomerangPDS/src/main/java/boomerang/solver/AbstractBoomerangSolver.java
@@ -27,7 +27,6 @@ import boomerang.scene.Statement;
 import boomerang.scene.Type;
 import boomerang.scene.Val;
 import boomerang.util.RegExAccessPath;
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
@@ -227,9 +226,9 @@ public abstract class AbstractBoomerangSolver<W extends Weight>
         });
   }
 
-  public Table<Edge, Val, W> asStatementValWeightTable() {
+  public Table<Edge, Val, W> asEdgeValWeightTable() {
     final Table<Edge, Val, W> results = HashBasedTable.create();
-    Stopwatch sw = Stopwatch.createStarted();
+
     WeightedPAutomaton<Edge, INode<Val>, W> callAut = getCallAutomaton();
     for (Entry<Transition<Edge, INode<Val>>, W> e :
         callAut.getTransitionsToFinalWeights().entrySet()) {
@@ -240,6 +239,25 @@ public abstract class AbstractBoomerangSolver<W extends Weight>
           && !t.getLabel().getMethod().equals(t.getStart().fact().m())) continue;
       results.put(t.getLabel(), t.getStart().fact(), w);
     }
+    return results;
+  }
+
+  public Table<Statement, Val, W> asStatementValWeightTable() {
+    Table<Statement, Val, W> results = HashBasedTable.create();
+
+    WeightedPAutomaton<Edge, INode<Val>, W> callAut = getCallAutomaton();
+    for (Entry<Transition<Edge, INode<Val>>, W> e :
+        callAut.getTransitionsToFinalWeights().entrySet()) {
+      Transition<Edge, INode<Val>> t = e.getKey();
+      W w = e.getValue();
+
+      if (t.getLabel().equals(new Edge(Statement.epsilon(), Statement.epsilon()))) continue;
+      if (t.getStart().fact().isLocal()
+          && !t.getLabel().getMethod().equals(t.getStart().fact().m())) continue;
+
+      results.put(t.getLabel().getStart(), t.getStart().fact(), w);
+    }
+
     return results;
   }
 

--- a/boomerangPDS/src/test/java/boomerang/guided/CustomFlowFunctionTest.java
+++ b/boomerangPDS/src/test/java/boomerang/guided/CustomFlowFunctionTest.java
@@ -23,6 +23,7 @@ import boomerang.scene.jimple.JimpleMethod;
 import boomerang.scene.jimple.SootCallGraph;
 import boomerang.solver.BackwardBoomerangSolver;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Table;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -107,11 +108,11 @@ public class CustomFlowFunctionTest {
 
     System.out.println("Solving query: " + query);
     ForwardBoomerangResults<NoWeight> res = solver.solve(query);
-    System.out.println(res.asStatementValWeightTable());
+    System.out.println(res.asEdgeValWeightTable());
 
     boolean t =
         res.asStatementValWeightTable().cellSet().stream()
-            .map(c -> c.getRowKey().getTarget())
+            .map(Table.Cell::getRowKey)
             .anyMatch(
                 statement ->
                     statement.containsInvokeExpr()

--- a/idealPDS/src/main/java/ideal/IDEALWeightFunctions.java
+++ b/idealPDS/src/main/java/ideal/IDEALWeightFunctions.java
@@ -69,7 +69,7 @@ public class IDEALWeightFunctions<W extends Weight> implements WeightFunctions<E
   public W normal(Node<Edge, Val> curr, Node<Edge, Val> succ) {
     W weight = delegate.normal(curr, succ);
     if (isObjectFlowPhase()
-        && succ.stmt().getTarget().containsInvokeExpr()
+        && succ.stmt().getStart().containsInvokeExpr()
         && !weight.equals(getOne())) {
       addOtherThanOneWeight(succ);
     }

--- a/idealPDS/src/main/java/inference/example/Main.java
+++ b/idealPDS/src/main/java/inference/example/Main.java
@@ -162,7 +162,7 @@ public class Main {
             resultHandler.getResults();
         for (Entry<WeightedForwardQuery<InferenceWeight>, ForwardBoomerangResults<InferenceWeight>>
             e : res.entrySet()) {
-          Table<Edge, Val, InferenceWeight> results = e.getValue().asStatementValWeightTable();
+          Table<Edge, Val, InferenceWeight> results = e.getValue().asEdgeValWeightTable();
           logger.info(Joiner.on("\n").join(results.cellSet()));
         }
       }

--- a/idealPDS/src/main/java/typestate/finiteautomata/TypeStateMachineWeightFunctions.java
+++ b/idealPDS/src/main/java/typestate/finiteautomata/TypeStateMachineWeightFunctions.java
@@ -71,8 +71,9 @@ public abstract class TypeStateMachineWeightFunctions
 
   @Override
   public TransitionFunction normal(Node<Edge, Val> curr, Node<Edge, Val> succ) {
-    if (succ.stmt().getTarget().containsInvokeExpr()) {
-      return callToReturn(curr, succ, succ.stmt().getTarget().getInvokeExpr());
+    Statement successor = succ.stmt().getStart();
+    if (successor.containsInvokeExpr()) {
+      return callToReturn(curr, succ, successor.getInvokeExpr());
     }
     return getOne();
   }

--- a/idealPDS/src/test/java/test/TestingResultReporter.java
+++ b/idealPDS/src/test/java/test/TestingResultReporter.java
@@ -15,11 +15,9 @@ import boomerang.results.ForwardBoomerangResults;
 import boomerang.scene.ControlFlowGraph.Edge;
 import boomerang.scene.Statement;
 import boomerang.scene.Val;
-import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
-import com.google.common.collect.Table.Cell;
 import java.util.Map.Entry;
 import java.util.Set;
 import sync.pds.solver.nodes.Node;
@@ -35,12 +33,7 @@ public class TestingResultReporter<W extends Weight> {
   }
 
   public void onSeedFinished(Node<Edge, Val> seed, final ForwardBoomerangResults<W> res) {
-    Table<Edge, Val, W> resultsAsCFGEdges = res.asStatementValWeightTable();
-    Table<Statement, Val, W> results = HashBasedTable.create();
-
-    for (Cell<Edge, Val, W> c : resultsAsCFGEdges.cellSet()) {
-      results.put(c.getRowKey().getTarget(), c.getColumnKey(), c.getValue());
-    }
+    Table<Statement, Val, W> results = res.asStatementValWeightTable();
 
     for (final Entry<Statement, Assertion> e : stmtToResults.entries()) {
       if (e.getValue() instanceof ComparableResult) {


### PR DESCRIPTION
- Weights in IDEAL were shifted in the results which required some post processing steps to extract the correct weights for their corresponding statements
- Rename `asStatementValWeightTable()` to `asEdgeValWeightTable()` to describe its functionality better and add a method  `asStatementValWeightTable()` which returns the actual statements