### PR TITLE
Some clean up for the scopes

### DIFF
--- a/boomerangPDS/src/main/java/boomerang/WeightedBoomerang.java
+++ b/boomerangPDS/src/main/java/boomerang/WeightedBoomerang.java
@@ -300,7 +300,8 @@ public abstract class WeightedBoomerang<W extends Weight> {
   protected void handleMapsForward(ForwardBoomerangSolver<W> solver, Node<Edge, Val> node) {
     Statement rstmt = node.stmt().getTarget();
     if (rstmt.containsInvokeExpr()) {
-      if (rstmt.isAssignStmt() && rstmt.getInvokeExpr().toString().contains(MAP_GET_SUB_SIGNATURE)) {
+      if (rstmt.isAssignStmt()
+          && rstmt.getInvokeExpr().toString().contains(MAP_GET_SUB_SIGNATURE)) {
         if (rstmt.getInvokeExpr().getBase().equals(node.fact())) {
           BackwardQuery bwq = BackwardQuery.make(node.stmt(), rstmt.getInvokeExpr().getArg(0));
           backwardSolve(bwq);

--- a/boomerangPDS/src/main/java/boomerang/callgraph/BoomerangResolver.java
+++ b/boomerangPDS/src/main/java/boomerang/callgraph/BoomerangResolver.java
@@ -86,7 +86,9 @@ public class BoomerangResolver implements ICallerCalleeResolutionStrategy {
           for (CallGraph.Edge e : precomputedCallGraph.edgesOutOf(s)) {
             // TODO Refactor. Should not be required, if the backward analysis is sound (data-flow
             // of static fields)
-            observableDynamicICFG.addCallIfNotInGraph(e.src(), e.tgt());
+            if (e.tgt().isDefined()) {
+              observableDynamicICFG.addCallIfNotInGraph(e.src(), e.tgt());
+            }
           }
         }
         if (FALLBACK_OPTION == NoCalleeFoundFallbackOptions.BYPASS) {

--- a/boomerangPDS/src/main/java/boomerang/callgraph/ObservableDynamicICFG.java
+++ b/boomerangPDS/src/main/java/boomerang/callgraph/ObservableDynamicICFG.java
@@ -67,8 +67,10 @@ public class ObservableDynamicICFG implements ObservableICFG<Statement, Method> 
       }
     }
 
-    for (Edge e : Lists.newArrayList(edges)) {
-      listener.onCalleeAdded(stmt, e.tgt());
+    for (Edge e : edges) {
+      if (e.tgt().isDefined()) {
+        listener.onCalleeAdded(stmt, e.tgt());
+      }
     }
 
     InvokeExpr ie = stmt.getInvokeExpr();

--- a/boomerangPDS/src/main/java/boomerang/callgraph/ObservableStaticICFG.java
+++ b/boomerangPDS/src/main/java/boomerang/callgraph/ObservableStaticICFG.java
@@ -39,9 +39,11 @@ public class ObservableStaticICFG implements ObservableICFG<Statement, Method> {
       }
     }
     for (CallGraph.Edge e : edges) {
-      listener.onCalleeAdded(listener.getObservedCaller(), e.tgt());
+      if (e.tgt().isDefined()) {
+        listener.onCalleeAdded(listener.getObservedCaller(), e.tgt());
+      }
     }
-    if (edges.size() == 0) {
+    if (edges.isEmpty()) {
       listener.onNoCalleeFound();
     }
   }

--- a/boomerangPDS/src/main/java/boomerang/flowfunction/FlowFunctionUtils.java
+++ b/boomerangPDS/src/main/java/boomerang/flowfunction/FlowFunctionUtils.java
@@ -5,6 +5,6 @@ import boomerang.scope.DeclaredMethod;
 public class FlowFunctionUtils {
   public static boolean isSystemArrayCopy(DeclaredMethod method) {
     return method.getName().equals("arraycopy")
-        && method.getDeclaringClass().getName().equals("java.lang.System");
+        && method.getDeclaringClass().getFullyQualifiedName().equals("java.lang.System");
   }
 }

--- a/boomerangPDS/src/main/java/boomerang/scope/AnalysisScope.java
+++ b/boomerangPDS/src/main/java/boomerang/scope/AnalysisScope.java
@@ -48,6 +48,7 @@ public abstract class AnalysisScope {
           Collection<CallGraph.Edge> edgesOutOf = cg.edgesOutOf(u);
           for (CallGraph.Edge e : edgesOutOf) {
             Method tgt = e.tgt();
+            if (tgt.isPhantom()) continue;
             if (!scanLibraryClasses && !tgt.getDeclaringClass().isApplicationClass()) continue;
 
             if (!processed.contains(tgt)) {

--- a/boomerangPDS/src/test/java/test/cases/array/ArrayTest.java
+++ b/boomerangPDS/src/test/java/test/cases/array/ArrayTest.java
@@ -11,6 +11,10 @@
  */
 package test.cases.array;
 
+import boomerang.scope.DataFlowScope;
+import boomerang.scope.DeclaredMethod;
+import boomerang.scope.Method;
+import boomerang.scope.WrappedClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import test.core.AbstractBoomerangTest;
@@ -117,5 +121,26 @@ public class ArrayTest extends AbstractBoomerangTest {
 
   private static class C {
     Object f;
+  }
+
+  @Override
+  public DataFlowScope getDataFlowScope() {
+    return new DataFlowScope() {
+      @Override
+      public boolean isExcluded(DeclaredMethod method) {
+        WrappedClass wrappedClass = method.getDeclaringClass();
+
+        return wrappedClass.isPhantom()
+            || wrappedClass.getFullyQualifiedName().equals("java.lang.System");
+      }
+
+      @Override
+      public boolean isExcluded(Method method) {
+        WrappedClass wrappedClass = method.getDeclaringClass();
+
+        return wrappedClass.isPhantom()
+            || wrappedClass.getFullyQualifiedName().equals("java.lang.System");
+      }
+    };
   }
 }

--- a/boomerangPDS/src/test/java/test/cases/sets/CustomSetTest.java
+++ b/boomerangPDS/src/test/java/test/cases/sets/CustomSetTest.java
@@ -11,6 +11,10 @@
  */
 package test.cases.sets;
 
+import boomerang.scope.DataFlowScope;
+import boomerang.scope.DeclaredMethod;
+import boomerang.scope.Method;
+import boomerang.scope.WrappedClass;
 import java.util.Iterator;
 import org.junit.Test;
 import test.cases.fields.Alloc;
@@ -101,5 +105,26 @@ public class CustomSetTest extends AbstractBoomerangTest {
 
       }
     }
+  }
+
+  @Override
+  public DataFlowScope getDataFlowScope() {
+    return new DataFlowScope() {
+      @Override
+      public boolean isExcluded(DeclaredMethod method) {
+        WrappedClass wrappedClass = method.getDeclaringClass();
+
+        return wrappedClass.isPhantom()
+            || wrappedClass.getFullyQualifiedName().equals("java.lang.Object");
+      }
+
+      @Override
+      public boolean isExcluded(Method method) {
+        WrappedClass wrappedClass = method.getDeclaringClass();
+
+        return wrappedClass.isPhantom()
+            || wrappedClass.getFullyQualifiedName().equals("java.lang.Object");
+      }
+    };
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootCallGraph.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootCallGraph.java
@@ -1,8 +1,10 @@
 package boomerang.scope.soot;
 
 import boomerang.scope.CallGraph;
+import boomerang.scope.Method;
 import boomerang.scope.Statement;
 import boomerang.scope.soot.jimple.JimpleMethod;
+import boomerang.scope.soot.jimple.JimplePhantomMethod;
 import boomerang.scope.soot.jimple.JimpleStatement;
 import java.util.Collection;
 import soot.SootMethod;
@@ -12,12 +14,22 @@ public class SootCallGraph extends CallGraph {
   public SootCallGraph(
       soot.jimple.toolkits.callgraph.CallGraph callGraph, Collection<SootMethod> entryPoints) {
     for (soot.jimple.toolkits.callgraph.Edge e : callGraph) {
-      if (e.src().hasActiveBody() && e.tgt().hasActiveBody() && e.srcStmt() != null) {
-        Statement callSite = JimpleStatement.create(e.srcStmt(), JimpleMethod.of(e.src()));
-        if (callSite.containsInvokeExpr()) {
-          LOGGER.trace("Call edge from {} to target method {}", callSite, e.tgt());
-          this.addEdge(new Edge(callSite, JimpleMethod.of(e.tgt())));
+      if (!e.src().hasActiveBody() || e.srcStmt() == null) {
+        continue;
+      }
+
+      Statement callSite = JimpleStatement.create(e.srcStmt(), JimpleMethod.of(e.src()));
+      if (callSite.containsInvokeExpr()) {
+        // Distinguish between loaded methods and phantom methods to cover all existing edges
+        Method target;
+        if (e.tgt().hasActiveBody()) {
+          target = JimpleMethod.of(e.tgt());
+        } else {
+          target = JimplePhantomMethod.of(e.tgt());
         }
+
+        LOGGER.trace("Call edge from {} to target method {}", callSite, e.tgt());
+        this.addEdge(new Edge(callSite, target));
       }
     }
 

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootDataFlowScopeUtil.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootDataFlowScopeUtil.java
@@ -38,15 +38,11 @@ public class SootDataFlowScopeUtil {
     return new DataFlowScope() {
       @Override
       public boolean isExcluded(DeclaredMethod method) {
-        JimpleDeclaredMethod m = (JimpleDeclaredMethod) method;
-        return ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate().isPhantom()
-            || m.isNative();
+        return method.getDeclaringClass().isPhantom();
       }
 
       public boolean isExcluded(Method method) {
-        JimpleMethod m = (JimpleMethod) method;
-        return ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate().isPhantom()
-            || m.isNative();
+        return method.getDeclaringClass().isPhantom();
       }
     };
   }
@@ -72,8 +68,7 @@ public class SootDataFlowScopeUtil {
             return true;
           }
         }
-        return ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate().isPhantom()
-            || m.isNative();
+        return m.getDeclaringClass().isPhantom();
       }
 
       public boolean isExcluded(Method method) {
@@ -89,8 +84,7 @@ public class SootDataFlowScopeUtil {
             return true;
           }
         }
-        return ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate().isPhantom()
-            || m.isNative();
+        return m.getDeclaringClass().isPhantom() || m.isPhantom();
       }
     };
   }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootDataFlowScopeUtil.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootDataFlowScopeUtil.java
@@ -64,9 +64,10 @@ public class SootDataFlowScopeUtil {
           }
         }
         for (Predicate<SootMethod> f : methodFilters) {
-          if (f.apply((SootMethod) m.getDelegate())) {
-            return true;
-          }
+          // TODO
+          // if (f.apply((SootMethod) m.getDelegate())) {
+          //  return true;
+          // }
         }
         return m.getDeclaringClass().isPhantom();
       }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootDataFlowScopeUtil.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootDataFlowScopeUtil.java
@@ -5,6 +5,7 @@ import boomerang.scope.DeclaredMethod;
 import boomerang.scope.Method;
 import boomerang.scope.soot.jimple.JimpleDeclaredMethod;
 import boomerang.scope.soot.jimple.JimpleMethod;
+import boomerang.scope.soot.jimple.JimpleWrappedClass;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Sets;
 import java.util.List;
@@ -38,12 +39,14 @@ public class SootDataFlowScopeUtil {
       @Override
       public boolean isExcluded(DeclaredMethod method) {
         JimpleDeclaredMethod m = (JimpleDeclaredMethod) method;
-        return ((SootClass) m.getDeclaringClass().getDelegate()).isPhantom() || m.isNative();
+        return ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate().isPhantom()
+            || m.isNative();
       }
 
       public boolean isExcluded(Method method) {
         JimpleMethod m = (JimpleMethod) method;
-        return ((SootClass) m.getDeclaringClass().getDelegate()).isPhantom() || m.isNative();
+        return ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate().isPhantom()
+            || m.isNative();
       }
     };
   }
@@ -59,7 +62,8 @@ public class SootDataFlowScopeUtil {
       public boolean isExcluded(DeclaredMethod method) {
         JimpleDeclaredMethod m = (JimpleDeclaredMethod) method;
         for (Predicate<SootClass> f : classFilters) {
-          if (f.apply((SootClass) m.getDeclaringClass().getDelegate())) {
+          SootClass sootClass = ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate();
+          if (f.apply(sootClass)) {
             return true;
           }
         }
@@ -68,13 +72,15 @@ public class SootDataFlowScopeUtil {
             return true;
           }
         }
-        return ((SootClass) m.getDeclaringClass().getDelegate()).isPhantom() || m.isNative();
+        return ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate().isPhantom()
+            || m.isNative();
       }
 
       public boolean isExcluded(Method method) {
         JimpleMethod m = (JimpleMethod) method;
         for (Predicate<SootClass> f : classFilters) {
-          if (f.apply((SootClass) m.getDeclaringClass().getDelegate())) {
+          SootClass sootClass = ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate();
+          if (f.apply(sootClass)) {
             return true;
           }
         }
@@ -83,7 +89,8 @@ public class SootDataFlowScopeUtil {
             return true;
           }
         }
-        return ((SootClass) m.getDeclaringClass().getDelegate()).isPhantom() || m.isNative();
+        return ((JimpleWrappedClass) m.getDeclaringClass()).getDelegate().isPhantom()
+            || m.isNative();
       }
     };
   }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootFrameworkScope.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/SootFrameworkScope.java
@@ -26,10 +26,10 @@ public class SootFrameworkScope implements FrameworkScope {
   protected DataFlowScope dataFlowScope;
 
   public SootFrameworkScope(
-      Scene scene,
-      soot.jimple.toolkits.callgraph.CallGraph callGraph,
-      Collection<SootMethod> entryPoints,
-      DataFlowScope dataFlowScope) {
+      @Nonnull Scene scene,
+      @Nonnull soot.jimple.toolkits.callgraph.CallGraph callGraph,
+      @Nonnull Collection<SootMethod> entryPoints,
+      @Nonnull DataFlowScope dataFlowScope) {
     this.scene = scene;
 
     this.sootCallGraph = new SootCallGraph(callGraph);
@@ -54,7 +54,7 @@ public class SootFrameworkScope implements FrameworkScope {
   public Stream<Method> handleStaticFieldInitializers(Val fact) {
     JimpleStaticFieldVal val = ((JimpleStaticFieldVal) fact);
     return ((JimpleField) val.field())
-        .getSootField().getDeclaringClass().getMethods().stream()
+        .getDelegate().getDeclaringClass().getMethods().stream()
             .filter(SootMethod::hasActiveBody)
             .map(JimpleMethod::of);
   }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleControlFlowGraph.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleControlFlowGraph.java
@@ -27,8 +27,6 @@ public class JimpleControlFlowGraph implements ControlFlowGraph {
 
   protected JimpleMethod method;
 
-  public JimpleControlFlowGraph() {}
-
   public JimpleControlFlowGraph(JimpleMethod method) {
     this.method = method;
     this.graph = new BriefUnitGraph(method.getDelegate().getActiveBody());

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleDeclaredMethod.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleDeclaredMethod.java
@@ -7,6 +7,7 @@ import boomerang.scope.Type;
 import boomerang.scope.WrappedClass;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import soot.SootMethod;
 
 public class JimpleDeclaredMethod extends DeclaredMethod {
@@ -29,11 +30,6 @@ public class JimpleDeclaredMethod extends DeclaredMethod {
   }
 
   @Override
-  public String toString() {
-    return delegate.toString();
-  }
-
-  @Override
   public String getName() {
     return delegate.getName();
   }
@@ -41,25 +37,6 @@ public class JimpleDeclaredMethod extends DeclaredMethod {
   @Override
   public boolean isStatic() {
     return delegate.isStatic();
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((delegate == null) ? 0 : delegate.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    JimpleDeclaredMethod other = (JimpleDeclaredMethod) obj;
-    if (delegate == null) {
-      return other.delegate == null;
-    } else return delegate.equals(other.delegate);
   }
 
   @Override
@@ -102,7 +79,25 @@ public class JimpleDeclaredMethod extends DeclaredMethod {
     return new JimpleType(delegate.getReturnType());
   }
 
-  public Object getDelegate() {
+  public SootMethod getDelegate() {
     return delegate;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    JimpleDeclaredMethod that = (JimpleDeclaredMethod) o;
+    return Objects.equals(delegate, that.delegate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate);
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleDeclaredMethod.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleDeclaredMethod.java
@@ -2,41 +2,30 @@ package boomerang.scope.soot.jimple;
 
 import boomerang.scope.DeclaredMethod;
 import boomerang.scope.InvokeExpr;
-import boomerang.scope.Method;
 import boomerang.scope.Type;
 import boomerang.scope.WrappedClass;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import soot.SootMethod;
+import soot.SootMethodRef;
 
 public class JimpleDeclaredMethod extends DeclaredMethod {
 
-  private final SootMethod delegate;
+  private final SootMethodRef delegate;
 
-  public JimpleDeclaredMethod(InvokeExpr inv, SootMethod method) {
+  public JimpleDeclaredMethod(InvokeExpr inv, SootMethodRef method) {
     super(inv);
     this.delegate = method;
   }
 
   @Override
-  public boolean isNative() {
-    return delegate.isNative();
-  }
-
-  @Override
   public String getSubSignature() {
-    return delegate.getSubSignature();
+    return delegate.getSubSignature().getString();
   }
 
   @Override
   public String getName() {
     return delegate.getName();
-  }
-
-  @Override
-  public boolean isStatic() {
-    return delegate.isStatic();
   }
 
   @Override
@@ -47,11 +36,6 @@ public class JimpleDeclaredMethod extends DeclaredMethod {
   @Override
   public String getSignature() {
     return delegate.getSignature();
-  }
-
-  @Override
-  public Method getCalledMethod() {
-    return JimpleMethod.of(delegate);
   }
 
   @Override
@@ -79,7 +63,7 @@ public class JimpleDeclaredMethod extends DeclaredMethod {
     return new JimpleType(delegate.getReturnType());
   }
 
-  public SootMethod getDelegate() {
+  public SootMethodRef getDelegate() {
     return delegate;
   }
 

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleDoubleVal.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleDoubleVal.java
@@ -3,9 +3,12 @@ package boomerang.scope.soot.jimple;
 import boomerang.scope.Method;
 import boomerang.scope.Val;
 import boomerang.scope.ValWithFalseVariable;
+import java.util.Objects;
 import soot.Value;
 
+// TODO May be removed
 public class JimpleDoubleVal extends JimpleVal implements ValWithFalseVariable {
+
   private final Val falseVariable;
 
   public JimpleDoubleVal(Value v, Method m, Val instanceofValue) {
@@ -18,26 +21,21 @@ public class JimpleDoubleVal extends JimpleVal implements ValWithFalseVariable {
   }
 
   @Override
-  public String toString() {
-    return "Instanceof " + falseVariable + " " + super.toString();
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    JimpleDoubleVal that = (JimpleDoubleVal) o;
+    return Objects.equals(falseVariable, that.falseVariable);
   }
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = super.hashCode();
-    result = prime * result + ((falseVariable == null) ? 0 : falseVariable.hashCode());
-    return result;
+    return Objects.hash(super.hashCode(), falseVariable);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (!super.equals(obj)) return false;
-    if (getClass() != obj.getClass()) return false;
-    JimpleDoubleVal other = (JimpleDoubleVal) obj;
-    if (falseVariable == null) {
-      return other.falseVariable == null;
-    } else return falseVariable.equals(other.falseVariable);
+  public String toString() {
+    return "InstanceOf " + falseVariable + " " + super.toString();
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleField.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleField.java
@@ -12,46 +12,42 @@
 package boomerang.scope.soot.jimple;
 
 import boomerang.scope.Field;
+import java.util.Objects;
 import soot.SootField;
 
 public class JimpleField extends Field {
+
   private final SootField delegate;
 
   public JimpleField(SootField delegate) {
-    super();
     this.delegate = delegate;
-  }
-
-  @Override
-  public String toString() {
-    return delegate.getName();
-  }
-
-  public SootField getSootField() {
-    return this.delegate;
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = super.hashCode();
-    result = prime * result + ((delegate == null) ? 0 : delegate.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (!super.equals(obj)) return false;
-    if (getClass() != obj.getClass()) return false;
-    JimpleField other = (JimpleField) obj;
-    if (delegate == null) {
-      return other.delegate == null;
-    } else return delegate.equals(other.delegate);
   }
 
   @Override
   public boolean isInnerClassField() {
     return this.delegate.getName().contains("$");
+  }
+
+  public SootField getDelegate() {
+    return this.delegate;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    JimpleField that = (JimpleField) o;
+    return Objects.equals(delegate, that.delegate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), delegate);
+  }
+
+  @Override
+  public String toString() {
+    return delegate.getName();
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleIfStatement.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleIfStatement.java
@@ -4,6 +4,7 @@ import boomerang.scope.IfStatement;
 import boomerang.scope.Method;
 import boomerang.scope.Statement;
 import boomerang.scope.Val;
+import java.util.Objects;
 import soot.Value;
 import soot.jimple.ConditionExpr;
 import soot.jimple.EqExpr;
@@ -68,7 +69,7 @@ public class JimpleIfStatement implements IfStatement {
         return Evaluation.TRUE;
       }
     }
-    return Evaluation.UNKOWN;
+    return Evaluation.UNKNOWN;
   }
 
   @Override
@@ -80,5 +81,18 @@ public class JimpleIfStatement implements IfStatement {
       return val.equals(new JimpleVal(op1, method)) || val.equals(new JimpleVal(op2, method));
     }
     return false;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    JimpleIfStatement that = (JimpleIfStatement) o;
+    return Objects.equals(delegate, that.delegate) && Objects.equals(method, that.method);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate, method);
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleInstanceFieldRef.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleInstanceFieldRef.java
@@ -4,6 +4,7 @@ import boomerang.scope.Field;
 import boomerang.scope.InstanceFieldRef;
 import boomerang.scope.Val;
 
+// TODO May be removed
 public class JimpleInstanceFieldRef implements InstanceFieldRef {
 
   private final soot.jimple.InstanceFieldRef delegate;

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleInvokeExpr.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleInvokeExpr.java
@@ -55,7 +55,7 @@ public class JimpleInvokeExpr implements InvokeExpr {
 
   @Override
   public DeclaredMethod getMethod() {
-    return new JimpleDeclaredMethod(this, delegate.getMethod());
+    return new JimpleDeclaredMethod(this, delegate.getMethodRef());
   }
 
   @Override

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleInvokeExpr.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleInvokeExpr.java
@@ -7,6 +7,7 @@ import boomerang.scope.Val;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import soot.jimple.InstanceInvokeExpr;
 import soot.jimple.SpecialInvokeExpr;
 import soot.jimple.StaticInvokeExpr;
@@ -15,13 +16,14 @@ public class JimpleInvokeExpr implements InvokeExpr {
 
   private final soot.jimple.InvokeExpr delegate;
   private final Method m;
-  private ArrayList<Val> cache;
+  private ArrayList<Val> argCache;
 
   public JimpleInvokeExpr(soot.jimple.InvokeExpr ive, Method m) {
     this.delegate = ive;
     this.m = m;
   }
 
+  @Override
   public Val getArg(int index) {
     if (delegate.getArg(index) == null) {
       return Val.zero();
@@ -29,35 +31,54 @@ public class JimpleInvokeExpr implements InvokeExpr {
     return new JimpleVal(delegate.getArg(index), m);
   }
 
+  @Override
   public List<Val> getArgs() {
-    if (cache == null) {
-      cache = Lists.newArrayList();
+    if (argCache == null) {
+      argCache = Lists.newArrayList();
       for (int i = 0; i < delegate.getArgCount(); i++) {
-        cache.add(getArg(i));
+        argCache.add(getArg(i));
       }
     }
-    return cache;
+    return argCache;
   }
 
+  @Override
   public boolean isInstanceInvokeExpr() {
     return delegate instanceof InstanceInvokeExpr;
   }
 
+  @Override
   public Val getBase() {
     InstanceInvokeExpr iie = (InstanceInvokeExpr) delegate;
     return new JimpleVal(iie.getBase(), m);
   }
 
+  @Override
   public DeclaredMethod getMethod() {
     return new JimpleDeclaredMethod(this, delegate.getMethod());
   }
 
+  @Override
   public boolean isSpecialInvokeExpr() {
     return delegate instanceof SpecialInvokeExpr;
   }
 
+  @Override
   public boolean isStaticInvokeExpr() {
     return delegate instanceof StaticInvokeExpr;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    JimpleInvokeExpr that = (JimpleInvokeExpr) o;
+    return Objects.equals(delegate, that.delegate) && Objects.equals(m, that.m);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate, m);
   }
 
   @Override

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleMethod.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleMethod.java
@@ -11,8 +11,9 @@ import com.google.common.collect.Interners;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
 import soot.Local;
 import soot.SootMethod;
 import soot.util.Chain;
@@ -24,13 +25,13 @@ public class JimpleMethod extends Method {
   protected static Interner<JimpleMethod> INTERNAL_POOL = Interners.newWeakInterner();
   protected ControlFlowGraph cfg;
   private List<Val> parameterLocalCache;
-  private Set<Val> localCache;
+  private Collection<Val> localCache;
 
-  protected JimpleMethod(SootMethod m) {
-    this.delegate = m;
-    if (!m.hasActiveBody()) {
+  protected JimpleMethod(SootMethod delegate) {
+    this.delegate = delegate;
+    if (!delegate.hasActiveBody()) {
       throw new RuntimeException(
-          "Building a Jimple method for " + m + " without active body present");
+          "Building a Jimple method for " + delegate + " without active body present");
     }
   }
 
@@ -39,33 +40,11 @@ public class JimpleMethod extends Method {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((delegate == null) ? 0 : delegate.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    JimpleMethod other = (JimpleMethod) obj;
-    if (delegate == null) {
-      return other.delegate == null;
-    } else return delegate.equals(other.delegate);
-  }
-
-  @Override
-  public String toString() {
-    return delegate != null ? delegate.toString() : "METHOD EPS";
-  }
-
   public boolean isStaticInitializer() {
     return delegate.isStaticInitializer();
   }
 
+  @Override
   public boolean isParameterLocal(Val val) {
     if (val.isStatic()) return false;
     if (!delegate.hasActiveBody()) {
@@ -91,10 +70,12 @@ public class JimpleMethod extends Method {
     return new JimpleType(delegate.getParameterType(index));
   }
 
+  @Override
   public Type getReturnType() {
     return new JimpleType(delegate.getReturnType());
   }
 
+  @Override
   public boolean isThisLocal(Val val) {
     if (val.isStatic()) return false;
     if (!delegate.hasActiveBody()) {
@@ -105,7 +86,8 @@ public class JimpleMethod extends Method {
     return parameterLocals.equals(val);
   }
 
-  public Set<Val> getLocals() {
+  @Override
+  public Collection<Val> getLocals() {
     if (localCache == null) {
       localCache = Sets.newHashSet();
       Chain<Local> locals = delegate.getActiveBody().getLocals();
@@ -116,10 +98,12 @@ public class JimpleMethod extends Method {
     return localCache;
   }
 
+  @Override
   public Val getThisLocal() {
     return new JimpleVal(delegate.getActiveBody().getThisLocal(), this);
   }
 
+  @Override
   public List<Val> getParameterLocals() {
     if (parameterLocalCache == null) {
       parameterLocalCache = Lists.newArrayList();
@@ -130,22 +114,27 @@ public class JimpleMethod extends Method {
     return parameterLocalCache;
   }
 
+  @Override
   public boolean isStatic() {
     return delegate.isStatic();
   }
 
+  @Override
   public boolean isNative() {
     return delegate.isNative();
   }
 
+  @Override
   public List<Statement> getStatements() {
     return getControlFlowGraph().getStatements();
   }
 
+  @Override
   public WrappedClass getDeclaringClass() {
     return new JimpleWrappedClass(delegate.getDeclaringClass());
   }
 
+  @Override
   public ControlFlowGraph getControlFlowGraph() {
     if (cfg == null) {
       cfg = new JimpleControlFlowGraph(this);
@@ -153,14 +142,12 @@ public class JimpleMethod extends Method {
     return cfg;
   }
 
+  @Override
   public String getSubSignature() {
     return delegate.getSubSignature();
   }
 
-  public SootMethod getDelegate() {
-    return delegate;
-  }
-
+  @Override
   public String getName() {
     return delegate.getName();
   }
@@ -170,8 +157,25 @@ public class JimpleMethod extends Method {
     return delegate.isConstructor();
   }
 
+  public SootMethod getDelegate() {
+    return delegate;
+  }
+
   @Override
-  public boolean isPublic() {
-    return delegate.isPublic();
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    JimpleMethod that = (JimpleMethod) o;
+    return Objects.equals(delegate, that.delegate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate);
+  }
+
+  @Override
+  public String toString() {
+    return delegate != null ? delegate.toString() : "METHOD_EPS";
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimplePhantomMethod.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimplePhantomMethod.java
@@ -38,8 +38,7 @@ public class JimplePhantomMethod extends Method {
 
   @Override
   public boolean isParameterLocal(Val val) {
-    List<Val> parameterLocals = getParameterLocals();
-    return parameterLocals.contains(val);
+    return false;
   }
 
   @Override
@@ -79,7 +78,8 @@ public class JimplePhantomMethod extends Method {
 
   @Override
   public List<Val> getParameterLocals() {
-    throw new RuntimeException("Parameter locals of phantom method are not available");
+    throw new RuntimeException(
+        "Parameter locals of phantom method " + delegate + " are not available");
   }
 
   @Override
@@ -109,7 +109,7 @@ public class JimplePhantomMethod extends Method {
 
   @Override
   public ControlFlowGraph getControlFlowGraph() {
-    throw new RuntimeException("CFG of phantom method is not available");
+    throw new RuntimeException("CFG of phantom method " + delegate + " is not available");
   }
 
   @Override

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleStaticFieldVal.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleStaticFieldVal.java
@@ -11,13 +11,14 @@
  */
 package boomerang.scope.soot.jimple;
 
-import boomerang.scope.ControlFlowGraph.Edge;
+import boomerang.scope.ControlFlowGraph;
 import boomerang.scope.Field;
 import boomerang.scope.Method;
 import boomerang.scope.Pair;
 import boomerang.scope.StaticFieldVal;
 import boomerang.scope.Type;
 import boomerang.scope.Val;
+import java.util.Objects;
 
 public class JimpleStaticFieldVal extends StaticFieldVal {
 
@@ -27,7 +28,7 @@ public class JimpleStaticFieldVal extends StaticFieldVal {
     this(field, m, null);
   }
 
-  private JimpleStaticFieldVal(JimpleField field, Method m, Edge unbalanced) {
+  private JimpleStaticFieldVal(JimpleField field, Method m, ControlFlowGraph.Edge unbalanced) {
     super(m, unbalanced);
     this.field = field;
   }
@@ -37,22 +38,18 @@ public class JimpleStaticFieldVal extends StaticFieldVal {
     return true;
   }
 
-  public String toString() {
-    return "StaticField: " + field + m;
-  }
-
   public Field field() {
     return field;
   }
 
   @Override
-  public Val asUnbalanced(Edge stmt) {
+  public Val asUnbalanced(ControlFlowGraph.Edge stmt) {
     return new JimpleStaticFieldVal(field, m, stmt);
   }
 
   @Override
   public Type getType() {
-    return new JimpleType(field.getSootField().getType());
+    return new JimpleType(field.getDelegate().getType());
   }
 
   @Override
@@ -161,25 +158,6 @@ public class JimpleStaticFieldVal extends StaticFieldVal {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = super.hashCode();
-    result = prime * result + ((field == null) ? 0 : field.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (!super.equals(obj)) return false;
-    if (getClass() != obj.getClass()) return false;
-    JimpleStaticFieldVal other = (JimpleStaticFieldVal) obj;
-    if (field == null) {
-      return other.field == null;
-    } else return field.equals(other.field);
-  }
-
-  @Override
   public boolean isLongConstant() {
     return false;
   }
@@ -202,5 +180,24 @@ public class JimpleStaticFieldVal extends StaticFieldVal {
   @Override
   public String getVariableName() {
     return toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    JimpleStaticFieldVal that = (JimpleStaticFieldVal) o;
+    return Objects.equals(field, that.field);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), field);
+  }
+
+  @Override
+  public String toString() {
+    return "StaticField: " + field;
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleType.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleType.java
@@ -6,6 +6,7 @@ import boomerang.scope.Val;
 import boomerang.scope.WrappedClass;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import soot.ArrayType;
 import soot.BooleanType;
@@ -23,10 +24,12 @@ public class JimpleType implements Type {
     this.delegate = type;
   }
 
+  @Override
   public boolean isNullType() {
     return delegate instanceof NullType;
   }
 
+  @Override
   public boolean isRefType() {
     return delegate instanceof RefType;
   }
@@ -36,14 +39,17 @@ public class JimpleType implements Type {
     return delegate instanceof BooleanType;
   }
 
+  @Override
   public boolean isArrayType() {
     return delegate instanceof ArrayType;
   }
 
+  @Override
   public Type getArrayBaseType() {
     return new JimpleType(((ArrayType) delegate).baseType);
   }
 
+  @Override
   public WrappedClass getWrappedClass() {
     return new JimpleWrappedClass(((RefType) delegate).getSootClass());
   }
@@ -126,30 +132,7 @@ public class JimpleType implements Type {
     return hierarchy.contains(thisClass);
   }
 
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((delegate == null) ? 0 : delegate.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    JimpleType other = (JimpleType) obj;
-    if (delegate == null) {
-      return other.delegate == null;
-    } else return delegate.equals(other.delegate);
-  }
-
-  @Override
-  public String toString() {
-    return delegate.toString();
-  }
-
+  // TODO Move to SootUtils
   private Collection<SootClass> getFullHierarchy(SootClass sourceClass, Set<SootClass> visited) {
     Set<SootClass> result = new HashSet<>();
 
@@ -185,5 +168,23 @@ public class JimpleType implements Type {
     }
 
     return result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    JimpleType that = (JimpleType) o;
+    return Objects.equals(delegate, that.delegate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate);
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleWrappedClass.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleWrappedClass.java
@@ -4,21 +4,22 @@ import boomerang.scope.Method;
 import boomerang.scope.Type;
 import boomerang.scope.WrappedClass;
 import com.google.common.collect.Sets;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
 import soot.SootClass;
 import soot.SootMethod;
 
 public class JimpleWrappedClass implements WrappedClass {
 
   private final SootClass delegate;
-  private Set<Method> methods;
+  private Collection<Method> methods;
 
   public JimpleWrappedClass(SootClass delegate) {
     this.delegate = delegate;
   }
 
-  public Set<Method> getMethods() {
+  public Collection<Method> getMethods() {
     List<SootMethod> ms = delegate.getMethods();
     if (methods == null) {
       methods = Sets.newHashSet();
@@ -46,41 +47,29 @@ public class JimpleWrappedClass implements WrappedClass {
   }
 
   @Override
-  public String toString() {
-    return delegate.toString();
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((delegate == null) ? 0 : delegate.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    JimpleWrappedClass other = (JimpleWrappedClass) obj;
-    if (delegate == null) {
-      return other.delegate == null;
-    } else return delegate.equals(other.delegate);
-  }
-
-  @Override
   public String getFullyQualifiedName() {
     return delegate.getName();
   }
 
-  @Override
-  public String getName() {
-    return delegate.getName();
+  public SootClass getDelegate() {
+    return delegate;
   }
 
   @Override
-  public Object getDelegate() {
-    return delegate;
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    JimpleWrappedClass that = (JimpleWrappedClass) o;
+    return Objects.equals(delegate, that.delegate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate);
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
   }
 }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleWrappedClass.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/jimple/JimpleWrappedClass.java
@@ -51,6 +51,11 @@ public class JimpleWrappedClass implements WrappedClass {
     return delegate.getName();
   }
 
+  @Override
+  public boolean isPhantom() {
+    return delegate.isPhantom();
+  }
+
   public SootClass getDelegate() {
     return delegate;
   }

--- a/boomerangScope-Soot/src/main/java/boomerang/scope/soot/sparse/SootAdapter.java
+++ b/boomerangScope-Soot/src/main/java/boomerang/scope/soot/sparse/SootAdapter.java
@@ -40,7 +40,7 @@ public class SootAdapter {
     if (val instanceof JimpleStaticFieldVal) {
       JimpleStaticFieldVal staticVal = (JimpleStaticFieldVal) val;
       Field field = staticVal.field();
-      SootField sootField = ((JimpleField) field).getSootField();
+      SootField sootField = ((JimpleField) field).getDelegate();
       SootFieldRef sootFieldRef = sootField.makeRef();
       StaticFieldRef srf = new MStaticFieldRef(sootFieldRef);
       return srf;
@@ -50,7 +50,7 @@ public class SootAdapter {
 
   public static SootField asField(Val val) {
     Field field = ((JimpleStaticFieldVal) val).field();
-    return ((JimpleField) field).getSootField();
+    return ((JimpleField) field).getDelegate();
   }
 
   public static SootMethod asSootMethod(Method m) {

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpDataFlowScope.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpDataFlowScope.java
@@ -19,13 +19,13 @@ public class SootUpDataFlowScope {
       public boolean isExcluded(DeclaredMethod method) {
         WrappedClass declaringClass = method.getDeclaringClass();
 
-        return method.isNative() || !declaringClass.isApplicationClass();
+        return !declaringClass.isApplicationClass();
       }
 
       public boolean isExcluded(Method method) {
         WrappedClass declaringClass = method.getDeclaringClass();
 
-        return method.isNative() || !declaringClass.isApplicationClass();
+        return method.isPhantom() || !declaringClass.isApplicationClass();
       }
     };
   }

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpDataFlowScopeUtil.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpDataFlowScopeUtil.java
@@ -70,9 +70,10 @@ public class SootUpDataFlowScopeUtil {
           }
         }
         for (Predicate<JavaSootMethod> f : methodFilters) {
-          if (f.apply(m.getDelegate())) {
-            return true;
-          }
+          // TODO
+          // if (f.apply(m.getDelegate())) {
+          //  return true;
+          // }
         }
         return m.getDeclaringClass() instanceof SootUpFrameworkScope.PhantomClass;
       }

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpDataFlowScopeUtil.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpDataFlowScopeUtil.java
@@ -41,15 +41,14 @@ public class SootUpDataFlowScopeUtil {
       public boolean isExcluded(DeclaredMethod method) {
         JimpleUpDeclaredMethod m = (JimpleUpDeclaredMethod) method;
         return ((JimpleUpWrappedClass) m.getDeclaringClass()).getDelegate()
-                instanceof SootUpFrameworkScope.PhantomClass
-            || m.isNative();
+            instanceof SootUpFrameworkScope.PhantomClass;
       }
 
       public boolean isExcluded(Method method) {
         JimpleUpMethod m = (JimpleUpMethod) method;
         return ((JimpleUpWrappedClass) m.getDeclaringClass()).getDelegate()
                 instanceof SootUpFrameworkScope.PhantomClass
-            || m.isNative();
+            || m.isPhantom();
       }
     };
   }
@@ -75,7 +74,7 @@ public class SootUpDataFlowScopeUtil {
             return true;
           }
         }
-        return m.getDeclaringClass() instanceof SootUpFrameworkScope.PhantomClass || m.isNative();
+        return m.getDeclaringClass() instanceof SootUpFrameworkScope.PhantomClass;
       }
 
       public boolean isExcluded(Method method) {
@@ -91,7 +90,7 @@ public class SootUpDataFlowScopeUtil {
             return true;
           }
         }
-        return m.getDeclaringClass() instanceof SootUpFrameworkScope.PhantomClass || m.isNative();
+        return m.getDeclaringClass() instanceof SootUpFrameworkScope.PhantomClass || m.isPhantom();
       }
     };
   }

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpDataFlowScopeUtil.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpDataFlowScopeUtil.java
@@ -5,6 +5,7 @@ import boomerang.scope.DeclaredMethod;
 import boomerang.scope.Method;
 import boomerang.scope.sootup.jimple.JimpleUpDeclaredMethod;
 import boomerang.scope.sootup.jimple.JimpleUpMethod;
+import boomerang.scope.sootup.jimple.JimpleUpWrappedClass;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Sets;
 import java.util.List;
@@ -39,13 +40,15 @@ public class SootUpDataFlowScopeUtil {
       @Override
       public boolean isExcluded(DeclaredMethod method) {
         JimpleUpDeclaredMethod m = (JimpleUpDeclaredMethod) method;
-        return m.getDeclaringClass().getDelegate() instanceof SootUpFrameworkScope.PhantomClass
+        return ((JimpleUpWrappedClass) m.getDeclaringClass()).getDelegate()
+                instanceof SootUpFrameworkScope.PhantomClass
             || m.isNative();
       }
 
       public boolean isExcluded(Method method) {
         JimpleUpMethod m = (JimpleUpMethod) method;
-        return m.getDeclaringClass().getDelegate() instanceof SootUpFrameworkScope.PhantomClass
+        return ((JimpleUpWrappedClass) m.getDeclaringClass()).getDelegate()
+                instanceof SootUpFrameworkScope.PhantomClass
             || m.isNative();
       }
     };
@@ -62,7 +65,8 @@ public class SootUpDataFlowScopeUtil {
       public boolean isExcluded(DeclaredMethod method) {
         JimpleUpDeclaredMethod m = (JimpleUpDeclaredMethod) method;
         for (Predicate<JavaSootClass> f : classFilters) {
-          if (f.apply((JavaSootClass) m.getDeclaringClass().getDelegate())) {
+          JavaSootClass sootClass = ((JimpleUpWrappedClass) m.getDeclaringClass()).getDelegate();
+          if (f.apply(sootClass)) {
             return true;
           }
         }
@@ -71,14 +75,14 @@ public class SootUpDataFlowScopeUtil {
             return true;
           }
         }
-        return m.getDeclaringClass().getDelegate() instanceof SootUpFrameworkScope.PhantomClass
-            || m.isNative();
+        return m.getDeclaringClass() instanceof SootUpFrameworkScope.PhantomClass || m.isNative();
       }
 
       public boolean isExcluded(Method method) {
         JimpleUpMethod m = (JimpleUpMethod) method;
         for (Predicate<JavaSootClass> f : classFilters) {
-          if (f.apply((JavaSootClass) m.getDeclaringClass().getDelegate())) {
+          JavaSootClass sootClass = ((JimpleUpWrappedClass) m.getDeclaringClass()).getDelegate();
+          if (f.apply(sootClass)) {
             return true;
           }
         }
@@ -87,8 +91,7 @@ public class SootUpDataFlowScopeUtil {
             return true;
           }
         }
-        return m.getDeclaringClass().getDelegate() instanceof SootUpFrameworkScope.PhantomClass
-            || m.isNative();
+        return m.getDeclaringClass() instanceof SootUpFrameworkScope.PhantomClass || m.isNative();
       }
     };
   }

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpFrameworkScope.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/SootUpFrameworkScope.java
@@ -119,8 +119,8 @@ public class SootUpFrameworkScope implements FrameworkScope {
 
   // ---
 
-  private static final String CONSTRUCTOR_NAME = "<init>";
-  private static final String STATIC_INITIALIZER_NAME = "<clinit>";
+  public static final String CONSTRUCTOR_NAME = "<init>";
+  public static final String STATIC_INITIALIZER_NAME = "<clinit>";
 
   public JavaView getView() {
     return view;

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpDeclaredMethod.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpDeclaredMethod.java
@@ -1,39 +1,33 @@
 package boomerang.scope.sootup.jimple;
 
 import boomerang.scope.DeclaredMethod;
-import boomerang.scope.Method;
 import boomerang.scope.Type;
 import boomerang.scope.WrappedClass;
 import boomerang.scope.sootup.SootUpFrameworkScope;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import sootup.core.signatures.MethodSignature;
 import sootup.java.core.JavaSootClass;
-import sootup.java.core.JavaSootMethod;
 import sootup.java.core.types.JavaClassType;
 
 public class JimpleUpDeclaredMethod extends DeclaredMethod {
 
-  private final JavaSootMethod delegate;
+  private final MethodSignature delegate;
 
-  public JimpleUpDeclaredMethod(JimpleUpInvokeExpr invokeExpr, JavaSootMethod delegate) {
+  public JimpleUpDeclaredMethod(JimpleUpInvokeExpr invokeExpr, MethodSignature delegate) {
     super(invokeExpr);
 
     this.delegate = delegate;
   }
 
-  public JavaSootMethod getDelegate() {
+  public MethodSignature getDelegate() {
     return delegate;
   }
 
   @Override
-  public boolean isNative() {
-    return delegate.isNative();
-  }
-
-  @Override
   public String getSubSignature() {
-    return delegate.getSignature().getSubSignature().toString();
+    return delegate.getSubSignature().toString();
   }
 
   @Override
@@ -42,30 +36,20 @@ public class JimpleUpDeclaredMethod extends DeclaredMethod {
   }
 
   @Override
-  public boolean isStatic() {
-    return delegate.isStatic();
-  }
-
-  @Override
   public boolean isConstructor() {
-    return SootUpFrameworkScope.isConstructor(delegate);
+    return delegate.getName().equals(SootUpFrameworkScope.CONSTRUCTOR_NAME);
   }
 
   @Override
   public String getSignature() {
-    return delegate.getSignature().toString();
-  }
-
-  @Override
-  public Method getCalledMethod() {
-    return JimpleUpMethod.of(delegate);
+    return delegate.toString();
   }
 
   @Override
   public WrappedClass getDeclaringClass() {
     JavaSootClass sootClass =
         SootUpFrameworkScope.getInstance()
-            .getSootClass((JavaClassType) delegate.getDeclaringClassType());
+            .getSootClass((JavaClassType) delegate.getDeclClassType());
     return new JimpleUpWrappedClass(sootClass);
   }
 
@@ -83,7 +67,7 @@ public class JimpleUpDeclaredMethod extends DeclaredMethod {
 
   @Override
   public Type getReturnType() {
-    return new JimpleUpType(delegate.getReturnType());
+    return new JimpleUpType(delegate.getType());
   }
 
   @Override

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpIfStatement.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpIfStatement.java
@@ -81,7 +81,7 @@ public class JimpleUpIfStatement implements IfStatement {
       }
     }
 
-    return Evaluation.UNKOWN;
+    return Evaluation.UNKNOWN;
   }
 
   @Override

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpInvokeExpr.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpInvokeExpr.java
@@ -3,7 +3,6 @@ package boomerang.scope.sootup.jimple;
 import boomerang.scope.DeclaredMethod;
 import boomerang.scope.InvokeExpr;
 import boomerang.scope.Val;
-import boomerang.scope.sootup.SootUpFrameworkScope;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -11,7 +10,6 @@ import sootup.core.jimple.common.expr.AbstractInstanceInvokeExpr;
 import sootup.core.jimple.common.expr.AbstractInvokeExpr;
 import sootup.core.jimple.common.expr.JSpecialInvokeExpr;
 import sootup.core.jimple.common.expr.JStaticInvokeExpr;
-import sootup.java.core.JavaSootMethod;
 
 public class JimpleUpInvokeExpr implements InvokeExpr {
 
@@ -60,14 +58,7 @@ public class JimpleUpInvokeExpr implements InvokeExpr {
 
   @Override
   public DeclaredMethod getMethod() {
-    JavaSootMethod sootMethod =
-        SootUpFrameworkScope.getInstance()
-            .getSootMethod(delegate.getMethodSignature())
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Can't find Method Declaration! " + delegate.getMethodSignature()));
-    return new JimpleUpDeclaredMethod(this, sootMethod);
+    return new JimpleUpDeclaredMethod(this, delegate.getMethodSignature());
   }
 
   @Override

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpMethod.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpMethod.java
@@ -162,11 +162,6 @@ public class JimpleUpMethod extends Method {
   }
 
   @Override
-  public boolean isPublic() {
-    return delegate.isPublic();
-  }
-
-  @Override
   public int hashCode() {
     return Arrays.hashCode(new Object[] {delegate});
   }

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpMethod.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpMethod.java
@@ -124,8 +124,13 @@ public class JimpleUpMethod extends Method {
   }
 
   @Override
-  public boolean isNative() {
-    return delegate.isNative();
+  public boolean isDefined() {
+    return true;
+  }
+
+  @Override
+  public boolean isPhantom() {
+    return false;
   }
 
   @Override

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpStatement.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpStatement.java
@@ -11,7 +11,6 @@ import boomerang.scope.sootup.SootUpFrameworkScope;
 import com.google.common.base.Joiner;
 import java.util.Arrays;
 import java.util.Collection;
-import sootup.core.jimple.common.constant.StringConstant;
 import sootup.core.jimple.common.expr.*;
 import sootup.core.jimple.common.ref.JArrayRef;
 import sootup.core.jimple.common.ref.JCaughtExceptionRef;
@@ -205,12 +204,6 @@ public class JimpleUpStatement extends Statement {
   public boolean isMultiArrayAllocation() {
     return (delegate instanceof JAssignStmt)
         && ((JAssignStmt) delegate).getRightOp() instanceof JNewMultiArrayExpr;
-  }
-
-  @Override
-  public boolean isStringAllocation() {
-    return delegate instanceof JAssignStmt
-        && ((JAssignStmt) delegate).getRightOp() instanceof StringConstant;
   }
 
   @Override

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpWrappedClass.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpWrappedClass.java
@@ -5,9 +5,9 @@ import boomerang.scope.Type;
 import boomerang.scope.WrappedClass;
 import boomerang.scope.sootup.SootUpFrameworkScope;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 import sootup.java.core.JavaSootClass;
 import sootup.java.core.JavaSootMethod;
 import sootup.java.core.types.JavaClassType;
@@ -15,14 +15,14 @@ import sootup.java.core.types.JavaClassType;
 public class JimpleUpWrappedClass implements WrappedClass {
 
   private final JavaSootClass delegate;
-  private Set<Method> methodsCache;
+  private Collection<Method> methodsCache;
 
   public JimpleUpWrappedClass(JavaSootClass delegate) {
     this.delegate = delegate;
   }
 
   @Override
-  public Set<Method> getMethods() {
+  public Collection<Method> getMethods() {
     if (methodsCache == null) {
       methodsCache = new HashSet<>();
 
@@ -66,13 +66,7 @@ public class JimpleUpWrappedClass implements WrappedClass {
     return delegate.getName();
   }
 
-  @Override
-  public String getName() {
-    return delegate.getName();
-  }
-
-  @Override
-  public Object getDelegate() {
+  public JavaSootClass getDelegate() {
     return delegate;
   }
 

--- a/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpWrappedClass.java
+++ b/boomerangScope-SootUp/src/main/java/boomerang/scope/sootup/jimple/JimpleUpWrappedClass.java
@@ -66,6 +66,12 @@ public class JimpleUpWrappedClass implements WrappedClass {
     return delegate.getName();
   }
 
+  @Override
+  public boolean isPhantom() {
+    // TODO May change
+    return false;
+  }
+
   public JavaSootClass getDelegate() {
     return delegate;
   }

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAClass.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAClass.java
@@ -57,6 +57,11 @@ public class WALAClass implements WrappedClass {
   }
 
   @Override
+  public boolean isPhantom() {
+    return false;
+  }
+
+  @Override
   public int hashCode() {
     final int prime = 31;
     int result = 1;

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAClass.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAClass.java
@@ -17,7 +17,7 @@ import boomerang.scope.WrappedClass;
 import com.ibm.wala.cast.java.ipa.callgraph.JavaSourceAnalysisScope;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
-import java.util.Set;
+import java.util.Collection;
 
 public class WALAClass implements WrappedClass {
 
@@ -28,7 +28,7 @@ public class WALAClass implements WrappedClass {
   }
 
   @Override
-  public Set<Method> getMethods() {
+  public Collection<Method> getMethods() {
     // TODO Auto-generated method stub
     return null;
   }
@@ -79,20 +79,14 @@ public class WALAClass implements WrappedClass {
   public String getFullyQualifiedName() {
     if (delegate.getName() == null) return "FAILED";
     if (delegate.getName().getPackage() == null) {
-      return getName();
+      return delegate.getName().getClassName().toString();
     }
     return delegate.getName().getPackage().toString().replace("/", ".")
         + "."
         + delegate.getName().getClassName();
   }
 
-  @Override
-  public String getName() {
-    return delegate.getName().getClassName().toString();
-  }
-
-  @Override
-  public Object getDelegate() {
+  public TypeReference getDelegate() {
     return delegate;
   }
 }

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAControlFlowGraph.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAControlFlowGraph.java
@@ -220,7 +220,7 @@ public class WALAControlFlowGraph implements ControlFlowGraph {
   private LinkedList<Statement> addUnitializedFields() {
     LinkedList<Statement> uninitializedStatements = Lists.newLinkedList();
     if (!method.isConstructor()) return uninitializedStatements;
-    TypeReference delegate = (TypeReference) method.getDeclaringClass().getDelegate();
+    TypeReference delegate = ((WALAClass) method.getDeclaringClass()).getDelegate();
     IClass c = cha.lookupClass(delegate);
     Collection<IField> allFields = c.getAllFields();
     List<FieldReference> allDeclaredFields = computeInitializedFields();

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALADataFlowScope.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALADataFlowScope.java
@@ -34,12 +34,12 @@ public class WALADataFlowScope {
       new DataFlowScope() {
         @Override
         public boolean isExcluded(DeclaredMethod method) {
-          return !method.getDeclaringClass().isApplicationClass() || method.isNative();
+          return !method.getDeclaringClass().isApplicationClass();
         }
 
         @Override
         public boolean isExcluded(Method method) {
-          return !method.getDeclaringClass().isApplicationClass() || method.isNative();
+          return !method.getDeclaringClass().isApplicationClass() || method.isPhantom();
         }
       };
 }

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALADeclaredMethod.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALADeclaredMethod.java
@@ -13,7 +13,6 @@ package boomerang.scope.wala;
 
 import boomerang.scope.DeclaredMethod;
 import boomerang.scope.InvokeExpr;
-import boomerang.scope.Method;
 import boomerang.scope.Type;
 import boomerang.scope.WrappedClass;
 import com.ibm.wala.types.MethodReference;
@@ -22,17 +21,10 @@ import java.util.List;
 public class WALADeclaredMethod extends DeclaredMethod {
 
   private final MethodReference delegate;
-  private final boolean isStatic;
 
   public WALADeclaredMethod(InvokeExpr inv, MethodReference ref) {
     super(inv);
     this.delegate = ref;
-    this.isStatic = inv.isStaticInvokeExpr();
-  }
-
-  @Override
-  public boolean isNative() {
-    return false;
   }
 
   @Override
@@ -46,11 +38,6 @@ public class WALADeclaredMethod extends DeclaredMethod {
   }
 
   @Override
-  public boolean isStatic() {
-    return isStatic;
-  }
-
-  @Override
   public boolean isConstructor() {
     return delegate.isInit();
   }
@@ -58,11 +45,6 @@ public class WALADeclaredMethod extends DeclaredMethod {
   @Override
   public String getSignature() {
     return delegate.getSignature();
-  }
-
-  @Override
-  public Method getCalledMethod() {
-    throw new RuntimeException("Not implemented");
   }
 
   @Override

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALADummyNullStatement.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALADummyNullStatement.java
@@ -151,11 +151,6 @@ public class WALADummyNullStatement extends WALAStatement {
   }
 
   @Override
-  public boolean isStringAllocation() {
-    return false;
-  }
-
-  @Override
   public boolean isFieldStore() {
     return false;
   }

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAIfStatement.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAIfStatement.java
@@ -50,7 +50,7 @@ public class WALAIfStatement implements IfStatement {
       }
     }
 
-    return Evaluation.UNKOWN;
+    return Evaluation.UNKNOWN;
   }
 
   @Override

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAMethod.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAMethod.java
@@ -190,11 +190,6 @@ public class WALAMethod extends Method {
     return delegate.isInit();
   }
 
-  @Override
-  public boolean isPublic() {
-    return delegate.isPublic();
-  }
-
   public Statement getBranchTarget(int target) {
     return cfg.getBranchTarget(target);
   }

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAMethod.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAMethod.java
@@ -120,8 +120,13 @@ public class WALAMethod extends Method {
   }
 
   @Override
-  public boolean isNative() {
-    return delegate.isNative();
+  public boolean isDefined() {
+    return true;
+  }
+
+  @Override
+  public boolean isPhantom() {
+    return false;
   }
 
   @Override

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAStatement.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAStatement.java
@@ -273,12 +273,6 @@ public class WALAStatement extends Statement {
   }
 
   @Override
-  public boolean isStringAllocation() {
-    // TODO Auto-generated method stub
-    return false;
-  }
-
-  @Override
   public boolean isFieldStore() {
     return delegate instanceof SSAPutInstruction && !((SSAPutInstruction) delegate).isStatic();
   }

--- a/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAUnitializedFieldStatement.java
+++ b/boomerangScope-WALA/src/main/java/boomerang/scope/wala/WALAUnitializedFieldStatement.java
@@ -128,11 +128,6 @@ public class WALAUnitializedFieldStatement extends WALAStatement {
   }
 
   @Override
-  public boolean isStringAllocation() {
-    return false;
-  }
-
-  @Override
   public boolean isFieldStore() {
     return true;
   }

--- a/boomerangScope/src/main/java/boomerang/scope/AllocVal.java
+++ b/boomerangScope/src/main/java/boomerang/scope/AllocVal.java
@@ -1,178 +1,165 @@
 package boomerang.scope;
 
 import boomerang.scope.ControlFlowGraph.Edge;
+import java.util.Objects;
 
 public class AllocVal extends Val {
 
   private final Val delegate;
-  private final Val allocationVal;
   private final Statement allocStatement;
+  private final Val allocationVal;
 
   public AllocVal(Val delegate, Statement allocStatement, Val allocationVal) {
-    super();
     this.delegate = delegate;
-    this.allocationVal = allocationVal;
     this.allocStatement = allocStatement;
+    this.allocationVal = allocationVal;
   }
 
-  public Type getType() {
-    return delegate.getType();
-  }
-
-  public Method m() {
-    return delegate.m();
-  }
-
-  public String toString() {
-    if (allocStatement.isAssignStmt()) {
-      if (allocStatement.getRightOp().isIntConstant()) {
-        return delegate + " Value (int): " + allocStatement.getRightOp().getIntValue();
-      }
-      if (allocStatement.getRightOp().isStringConstant()) {
-        return delegate + " Value (String): " + allocStatement.getRightOp().getStringValue();
-      }
-    }
-    if (delegate == null) return "";
-    return delegate.toString();
-  }
-
-  public boolean isStatic() {
-    return delegate.isStatic();
-  }
-
-  public boolean isNewExpr() {
-    return delegate.isNewExpr();
-  }
-
-  public Type getNewExprType() {
-    return delegate.getNewExprType();
-  }
-
-  public boolean isUnbalanced() {
-    return delegate.isUnbalanced();
-  }
-
-  public Val asUnbalanced(Edge stmt) {
-    return delegate.asUnbalanced(stmt);
-  }
-
-  public boolean isLocal() {
-    return delegate.isLocal();
-  }
-
-  public boolean isArrayAllocationVal() {
-    return delegate.isArrayAllocationVal();
-  }
-
-  public Val getArrayAllocationSize() {
-    return delegate.getArrayAllocationSize();
-  }
-
-  public boolean isNull() {
-    return allocationVal.isNull();
-  }
-
-  public boolean isStringConstant() {
-    return delegate.isStringConstant();
-  }
-
-  public String getStringValue() {
-    return delegate.getStringValue();
-  }
-
-  public boolean isStringBufferOrBuilder() {
-    return delegate.isStringBufferOrBuilder();
-  }
-
-  public boolean isThrowableAllocationType() {
-    return delegate.isThrowableAllocationType();
-  }
-
-  public boolean isCast() {
-    return delegate.isCast();
-  }
-
-  public Val getCastOp() {
-    return delegate.getCastOp();
-  }
-
-  public boolean isArrayRef() {
-    return delegate.isArrayRef();
-  }
-
-  public boolean isInstanceOfExpr() {
-    return delegate.isInstanceOfExpr();
-  }
-
-  public Val getInstanceOfOp() {
-    return delegate.getInstanceOfOp();
-  }
-
-  public boolean isLengthExpr() {
-    return delegate.isLengthExpr();
-  }
-
-  public Val getLengthOp() {
-    return delegate.getLengthOp();
-  }
-
-  public boolean isIntConstant() {
-    return delegate.isIntConstant();
-  }
-
-  public boolean isClassConstant() {
-    return delegate.isClassConstant();
-  }
-
-  public Type getClassConstantType() {
-    return delegate.getClassConstantType();
-  }
-
-  public Val withNewMethod(Method callee) {
-    return delegate.withNewMethod(callee);
-  }
-
-  public Val withSecondVal(Val leftOp) {
-    return delegate.withSecondVal(leftOp);
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = super.hashCode();
-    result = prime * result + ((allocStatement == null) ? 0 : allocStatement.hashCode());
-    result = prime * result + ((allocationVal == null) ? 0 : allocationVal.hashCode());
-    result = prime * result + ((delegate == null) ? 0 : delegate.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (!super.equals(obj)) return false;
-    if (getClass() != obj.getClass()) return false;
-    AllocVal other = (AllocVal) obj;
-    if (allocStatement == null) {
-      if (other.allocStatement != null) return false;
-    } else if (!allocStatement.equals(other.allocStatement)) return false;
-    if (allocationVal == null) {
-      if (other.allocationVal != null) return false;
-    } else if (!allocationVal.equals(other.allocationVal)) return false;
-    if (delegate == null) {
-      return other.delegate == null;
-    } else return delegate.equals(other.delegate);
-  }
-
-  public Val getAllocVal() {
-    return allocationVal;
+  public Val getDelegate() {
+    return delegate;
   }
 
   public Statement getAllocStatement() {
     return allocStatement;
   }
 
-  public Val getDelegate() {
-    return delegate;
+  public Val getAllocVal() {
+    return allocationVal;
+  }
+
+  @Override
+  public Type getType() {
+    return delegate.getType();
+  }
+
+  @Override
+  public Method m() {
+    return delegate.m();
+  }
+
+  @Override
+  public boolean isStatic() {
+    return delegate.isStatic();
+  }
+
+  @Override
+  public boolean isNewExpr() {
+    return delegate.isNewExpr();
+  }
+
+  @Override
+  public Type getNewExprType() {
+    return delegate.getNewExprType();
+  }
+
+  @Override
+  public boolean isUnbalanced() {
+    return delegate.isUnbalanced();
+  }
+
+  @Override
+  public Val asUnbalanced(Edge stmt) {
+    return delegate.asUnbalanced(stmt);
+  }
+
+  @Override
+  public boolean isLocal() {
+    return delegate.isLocal();
+  }
+
+  @Override
+  public boolean isArrayAllocationVal() {
+    return delegate.isArrayAllocationVal();
+  }
+
+  @Override
+  public Val getArrayAllocationSize() {
+    return delegate.getArrayAllocationSize();
+  }
+
+  @Override
+  public boolean isNull() {
+    return allocationVal.isNull();
+  }
+
+  @Override
+  public boolean isStringConstant() {
+    return delegate.isStringConstant();
+  }
+
+  @Override
+  public String getStringValue() {
+    return delegate.getStringValue();
+  }
+
+  @Override
+  public boolean isStringBufferOrBuilder() {
+    return delegate.isStringBufferOrBuilder();
+  }
+
+  @Override
+  public boolean isThrowableAllocationType() {
+    return delegate.isThrowableAllocationType();
+  }
+
+  @Override
+  public boolean isCast() {
+    return delegate.isCast();
+  }
+
+  @Override
+  public Val getCastOp() {
+    return delegate.getCastOp();
+  }
+
+  @Override
+  public boolean isArrayRef() {
+    return delegate.isArrayRef();
+  }
+
+  @Override
+  public boolean isInstanceOfExpr() {
+    return delegate.isInstanceOfExpr();
+  }
+
+  @Override
+  public Val getInstanceOfOp() {
+    return delegate.getInstanceOfOp();
+  }
+
+  @Override
+  public boolean isLengthExpr() {
+    return delegate.isLengthExpr();
+  }
+
+  @Override
+  public Val getLengthOp() {
+    return delegate.getLengthOp();
+  }
+
+  @Override
+  public boolean isIntConstant() {
+    return delegate.isIntConstant();
+  }
+
+  @Override
+  public boolean isClassConstant() {
+    return delegate.isClassConstant();
+  }
+
+  @Override
+  public Type getClassConstantType() {
+    return delegate.getClassConstantType();
+  }
+
+  @Override
+  public Val withNewMethod(Method callee) {
+    return delegate.withNewMethod(callee);
+  }
+
+  @Override
+  public Val withSecondVal(Val leftOp) {
+    return delegate.withSecondVal(leftOp);
   }
 
   @Override
@@ -198,5 +185,33 @@ public class AllocVal extends Val {
   @Override
   public String getVariableName() {
     return delegate.getVariableName();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    AllocVal allocVal = (AllocVal) o;
+    return Objects.equals(delegate, allocVal.getDelegate())
+        && Objects.equals(allocStatement, allocVal.getAllocStatement())
+        && Objects.equals(allocationVal, allocVal.getAllocVal());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), delegate, allocStatement, allocationVal);
+  }
+
+  @Override
+  public String toString() {
+    return "AllocVal{"
+        + "delegate="
+        + delegate
+        + ", allocStatement="
+        + allocStatement
+        + ", allocationVal="
+        + allocationVal
+        + '}';
   }
 }

--- a/boomerangScope/src/main/java/boomerang/scope/CallGraph.java
+++ b/boomerangScope/src/main/java/boomerang/scope/CallGraph.java
@@ -4,6 +4,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,26 +43,16 @@ public class CallGraph {
     }
 
     @Override
-    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((callSite == null) ? 0 : callSite.hashCode());
-      result = prime * result + ((callee == null) ? 0 : callee.hashCode());
-      return result;
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Edge edge = (Edge) o;
+      return Objects.equals(callSite, edge.callSite) && Objects.equals(callee, edge.callee);
     }
 
     @Override
-    public boolean equals(Object obj) {
-      if (this == obj) return true;
-      if (obj == null) return false;
-      if (getClass() != obj.getClass()) return false;
-      Edge other = (Edge) obj;
-      if (callSite == null) {
-        if (other.callSite != null) return false;
-      } else if (!callSite.equals(other.callSite)) return false;
-      if (callee == null) {
-        return other.callee == null;
-      } else return callee.equals(other.callee);
+    public int hashCode() {
+      return Objects.hash(callSite, callee);
     }
 
     @Override
@@ -73,7 +64,11 @@ public class CallGraph {
   public boolean addEdge(Edge edge) {
     edgesOutOf.put(edge.callSite, edge);
     edgesInto.put(edge.tgt(), edge);
-    computeStaticFieldsLoadAndStores(edge.tgt());
+
+    if (edge.tgt().isDefined()) {
+      computeStaticFieldsLoadAndStores(edge.tgt());
+    }
+
     return edges.add(edge);
   }
 

--- a/boomerangScope/src/main/java/boomerang/scope/CallGraph.java
+++ b/boomerangScope/src/main/java/boomerang/scope/CallGraph.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 
 public class CallGraph {
 
-  protected Logger LOGGER = LoggerFactory.getLogger(CallGraph.class);
+  protected static final Logger LOGGER = LoggerFactory.getLogger(CallGraph.class);
   private final Set<Edge> edges = Sets.newHashSet();
   private final Multimap<Statement, Edge> edgesOutOf = HashMultimap.create();
   private final Multimap<Method, Edge> edgesInto = HashMultimap.create();

--- a/boomerangScope/src/main/java/boomerang/scope/DataFlowScope.java
+++ b/boomerangScope/src/main/java/boomerang/scope/DataFlowScope.java
@@ -1,20 +1,6 @@
 package boomerang.scope;
 
 public interface DataFlowScope {
-
-  DataFlowScope INCLUDE_ALL =
-      new DataFlowScope() {
-        @Override
-        public boolean isExcluded(DeclaredMethod method) {
-          return false;
-        }
-
-        @Override
-        public boolean isExcluded(Method method) {
-          return false;
-        }
-      };
-
   boolean isExcluded(DeclaredMethod method);
 
   boolean isExcluded(Method method);

--- a/boomerangScope/src/main/java/boomerang/scope/DataFlowScope.java
+++ b/boomerangScope/src/main/java/boomerang/scope/DataFlowScope.java
@@ -1,6 +1,7 @@
 package boomerang.scope;
 
 public interface DataFlowScope {
+
   boolean isExcluded(DeclaredMethod method);
 
   boolean isExcluded(Method method);

--- a/boomerangScope/src/main/java/boomerang/scope/DeclaredMethod.java
+++ b/boomerangScope/src/main/java/boomerang/scope/DeclaredMethod.java
@@ -1,6 +1,7 @@
 package boomerang.scope;
 
 import java.util.List;
+import java.util.Objects;
 
 public abstract class DeclaredMethod {
 
@@ -10,6 +11,7 @@ public abstract class DeclaredMethod {
     this.inv = inv;
   }
 
+  // TODO May be removed
   public abstract boolean isNative();
 
   public abstract String getSubSignature();
@@ -34,5 +36,23 @@ public abstract class DeclaredMethod {
 
   public InvokeExpr getInvokeExpr() {
     return inv;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DeclaredMethod that = (DeclaredMethod) o;
+    return Objects.equals(inv, that.inv);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(inv);
+  }
+
+  @Override
+  public String toString() {
+    return inv.toString();
   }
 }

--- a/boomerangScope/src/main/java/boomerang/scope/DeclaredMethod.java
+++ b/boomerangScope/src/main/java/boomerang/scope/DeclaredMethod.java
@@ -11,20 +11,13 @@ public abstract class DeclaredMethod {
     this.inv = inv;
   }
 
-  // TODO May be removed
-  public abstract boolean isNative();
-
   public abstract String getSubSignature();
 
   public abstract String getName();
 
-  public abstract boolean isStatic();
-
   public abstract boolean isConstructor();
 
   public abstract String getSignature();
-
-  public abstract Method getCalledMethod();
 
   public abstract WrappedClass getDeclaringClass();
 

--- a/boomerangScope/src/main/java/boomerang/scope/Field.java
+++ b/boomerangScope/src/main/java/boomerang/scope/Field.java
@@ -11,13 +11,14 @@
  */
 package boomerang.scope;
 
-import com.google.common.base.Objects;
 import de.fraunhofer.iem.Empty;
 import de.fraunhofer.iem.Location;
 import de.fraunhofer.iem.wildcard.ExclusionWildcard;
 import de.fraunhofer.iem.wildcard.Wildcard;
+import java.util.Objects;
 
 public class Field implements Location {
+
   private final String rep;
 
   private Field(String rep) {
@@ -28,42 +29,30 @@ public class Field implements Location {
     this.rep = null;
   }
 
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((rep == null) ? 0 : rep.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    Field other = (Field) obj;
-    if (rep == null) {
-      return other.rep == null;
-    } else return rep.equals(other.rep);
-  }
-
-  @Override
-  public String toString() {
-    return rep;
-  }
-
   public static Field wildcard() {
     return new WildcardField();
   }
 
   public static Field empty() {
     return new EmptyField("{}");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Field field = (Field) o;
+    return Objects.equals(rep, field.rep);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rep);
+  }
+
+  @Override
+  public String toString() {
+    return rep;
   }
 
   private static class EmptyField extends Field implements Empty {
@@ -105,38 +94,28 @@ public class Field implements Location {
     }
 
     @Override
-    public String toString() {
-      return "not " + excludes;
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      if (!super.equals(o)) return false;
+      ExclusionWildcardField that = (ExclusionWildcardField) o;
+      return Objects.equals(excludes, that.excludes);
     }
 
     @Override
     public int hashCode() {
-      final int prime = 31;
-      int result = super.hashCode();
-      result = prime * result + ((excludes == null) ? 0 : excludes.hashCode());
-      return result;
+      return Objects.hash(super.hashCode(), excludes);
     }
 
     @Override
-    public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      }
-      if (!super.equals(obj)) {
-        return false;
-      }
-      if (getClass() != obj.getClass()) {
-        return false;
-      }
-      ExclusionWildcardField other = (ExclusionWildcardField) obj;
-      if (excludes == null) {
-        return other.excludes == null;
-      } else return excludes.equals(other.excludes);
+    public String toString() {
+      return "not " + excludes;
     }
   }
 
   public static class ArrayField extends Field {
-    int index = -1;
+
+    private final int index;
 
     private ArrayField(int index) {
       super("array");
@@ -148,31 +127,8 @@ public class Field implements Location {
 
     public ArrayField() {
       super("array");
-    }
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      if (!super.equals(o)) {
-        return false;
-      }
-      ArrayField that = (ArrayField) o;
-      return index == that.index;
-    }
-
-    @Override
-    public String toString() {
-      return super.toString() + (index == -1 ? " ANY_INDEX" : "Index: " + index);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(super.hashCode(), index);
+      this.index = -1;
     }
 
     @Override
@@ -183,6 +139,25 @@ public class Field implements Location {
 
     public int getIndex() {
       return index;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      if (!super.equals(o)) return false;
+      ArrayField that = (ArrayField) o;
+      return index == that.index;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), index);
+    }
+
+    @Override
+    public String toString() {
+      return super.toString() + (index == -1 ? " ANY_INDEX" : "Index: " + index);
     }
   }
 

--- a/boomerangScope/src/main/java/boomerang/scope/IfStatement.java
+++ b/boomerangScope/src/main/java/boomerang/scope/IfStatement.java
@@ -4,7 +4,7 @@ public interface IfStatement {
   enum Evaluation {
     TRUE,
     FALSE,
-    UNKOWN
+    UNKNOWN
   }
 
   Statement getTarget();

--- a/boomerangScope/src/main/java/boomerang/scope/Method.java
+++ b/boomerangScope/src/main/java/boomerang/scope/Method.java
@@ -69,8 +69,13 @@ public abstract class Method implements Location {
             }
 
             @Override
-            public boolean isNative() {
+            public boolean isDefined() {
               return false;
+            }
+
+            @Override
+            public boolean isPhantom() {
+              return true;
             }
 
             @Override
@@ -131,7 +136,9 @@ public abstract class Method implements Location {
 
   public abstract boolean isStatic();
 
-  public abstract boolean isNative();
+  public abstract boolean isDefined();
+
+  public abstract boolean isPhantom();
 
   public abstract List<Statement> getStatements();
 

--- a/boomerangScope/src/main/java/boomerang/scope/Method.java
+++ b/boomerangScope/src/main/java/boomerang/scope/Method.java
@@ -1,14 +1,15 @@
 package boomerang.scope;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import de.fraunhofer.iem.Location;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 public abstract class Method implements Location {
+
   private static Method epsilon;
+  private Collection<Val> returnLocals;
 
   protected Method() {}
 
@@ -16,15 +17,6 @@ public abstract class Method implements Location {
     if (epsilon == null)
       epsilon =
           new Method() {
-            @Override
-            public int hashCode() {
-              return System.identityHashCode(this);
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-              return obj == this;
-            }
 
             @Override
             public boolean isStaticInitializer() {
@@ -38,17 +30,17 @@ public abstract class Method implements Location {
 
             @Override
             public List<Type> getParameterTypes() {
-              return Lists.newArrayList();
+              return Collections.emptyList();
             }
 
             @Override
             public Type getParameterType(int index) {
-              return null;
+              throw new RuntimeException("Epsilon method has no parameters");
             }
 
             @Override
             public Type getReturnType() {
-              return null;
+              throw new RuntimeException("Epsilon method has no return type");
             }
 
             @Override
@@ -57,18 +49,18 @@ public abstract class Method implements Location {
             }
 
             @Override
-            public Set<Val> getLocals() {
-              return Sets.newHashSet();
+            public Collection<Val> getLocals() {
+              return Collections.emptySet();
             }
 
             @Override
             public Val getThisLocal() {
-              return null;
+              throw new RuntimeException("Epsilon method has no this local");
             }
 
             @Override
             public List<Val> getParameterLocals() {
-              return Lists.newArrayList();
+              return Collections.emptyList();
             }
 
             @Override
@@ -83,27 +75,27 @@ public abstract class Method implements Location {
 
             @Override
             public List<Statement> getStatements() {
-              return Lists.newArrayList();
+              return Collections.emptyList();
             }
 
             @Override
             public WrappedClass getDeclaringClass() {
-              return null;
+              throw new RuntimeException("Epsilon method has no declaring class");
             }
 
             @Override
             public ControlFlowGraph getControlFlowGraph() {
-              return null;
+              throw new RuntimeException("Epsilon method has no control flow graph");
             }
 
             @Override
             public String getSubSignature() {
-              return null;
+              return "EPS";
             }
 
             @Override
             public String getName() {
-              return null;
+              return "EPS";
             }
 
             @Override
@@ -112,17 +104,11 @@ public abstract class Method implements Location {
             }
 
             @Override
-            public boolean isPublic() {
-              return false;
+            public String toString() {
+              return "METHOD_EPS";
             }
           };
     return epsilon;
-  }
-
-  // TODO: [ms] looks as if this toString() should go into epsilon..
-  @Override
-  public String toString() {
-    return "METHOD EPS";
   }
 
   public abstract boolean isStaticInitializer();
@@ -137,7 +123,7 @@ public abstract class Method implements Location {
 
   public abstract boolean isThisLocal(Val val);
 
-  public abstract Set<Val> getLocals();
+  public abstract Collection<Val> getLocals();
 
   public abstract Val getThisLocal();
 
@@ -162,10 +148,6 @@ public abstract class Method implements Location {
   }
 
   public abstract boolean isConstructor();
-
-  public abstract boolean isPublic();
-
-  private Collection<Val> returnLocals;
 
   public Collection<Val> getReturnLocals() {
     if (returnLocals == null) {

--- a/boomerangScope/src/main/java/boomerang/scope/Pair.java
+++ b/boomerangScope/src/main/java/boomerang/scope/Pair.java
@@ -1,6 +1,9 @@
 package boomerang.scope;
 
+import java.util.Objects;
+
 public class Pair<X, Y> {
+
   private final Y y;
   private final X x;
 
@@ -18,30 +21,20 @@ public class Pair<X, Y> {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((x == null) ? 0 : x.hashCode());
-    result = prime * result + ((y == null) ? 0 : y.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    Pair other = (Pair) obj;
-    if (x == null) {
-      if (other.x != null) return false;
-    } else if (!x.equals(other.x)) return false;
-    if (y == null) {
-      return other.y == null;
-    } else return y.equals(other.y);
-  }
-
-  @Override
   public String toString() {
     return "Pair(" + x + "," + y + ")";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Pair<?, ?> pair = (Pair<?, ?>) o;
+    return Objects.equals(y, pair.y) && Objects.equals(x, pair.x);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(y, x);
   }
 }

--- a/boomerangScope/src/main/java/boomerang/scope/Statement.java
+++ b/boomerangScope/src/main/java/boomerang/scope/Statement.java
@@ -14,9 +14,10 @@ package boomerang.scope;
 import de.fraunhofer.iem.Empty;
 import de.fraunhofer.iem.Location;
 import java.util.Collection;
+import java.util.Objects;
 
 public abstract class Statement implements Location {
-  // Wrapper for stmt so we know the method
+
   private static Statement epsilon;
   private final String rep;
   protected final Method method;
@@ -46,258 +47,211 @@ public abstract class Statement implements Location {
 
     @Override
     public Method getMethod() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
     public boolean containsStaticFieldAccess() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean containsInvokeExpr() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public Field getWrittenField() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement is not a field write statement");
     }
 
     @Override
     public boolean isFieldWriteWithBase(Val base) {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public Field getLoadedField() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement is not a field load statement");
     }
 
     @Override
     public boolean isFieldLoadWithBase(Val base) {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isParameter(Val value) {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean assignsValue(Val value) {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isReturnOperator(Val val) {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean uses(Val value) {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isAssignStmt() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public Val getLeftOp() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement is not an assign statement");
     }
 
     @Override
     public Val getRightOp() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement is not an assign statement");
     }
 
     @Override
     public boolean isInstanceOfStatement(Val fact) {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isCast() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public InvokeExpr getInvokeExpr() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement has no invoke expression");
     }
 
     @Override
     public boolean isReturnStmt() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isThrowStmt() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isIfStmt() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public IfStatement getIfStmt() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement is not an if statement");
     }
 
     @Override
     public Val getReturnOp() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement is not a return statement");
     }
 
     @Override
     public boolean isMultiArrayAllocation() {
-      // TODO Auto-generated method stub
-      return false;
-    }
-
-    @Override
-    public boolean isStringAllocation() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isFieldStore() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isArrayStore() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isArrayLoad() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isFieldLoad() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isIdentityStmt() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean killAtIfStmt(Val fact, Statement successor) {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public Pair<Val, Field> getFieldStore() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement is not a field store statement");
     }
 
     @Override
     public Pair<Val, Field> getFieldLoad() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement is not a field load statement");
     }
 
     @Override
     public boolean isStaticFieldLoad() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isStaticFieldStore() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public StaticFieldVal getStaticField() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement has no static field");
     }
 
     @Override
     public boolean isPhiStatement() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public Collection<Val> getPhiVals() {
-      return null;
+      throw new RuntimeException("Epsilon statement is not a phi statement");
     }
 
     @Override
     public Pair<Val, Integer> getArrayBase() {
-      // TODO Auto-generated method stub
-      return null;
+      throw new RuntimeException("Epsilon statement has no array base");
     }
 
     @Override
     public int getStartLineNumber() {
-      // TODO Auto-generated method stub
-      return 0;
+      return -1;
     }
 
     @Override
     public int getStartColumnNumber() {
-      // TODO Auto-generated method stub
-      return 0;
+      return -1;
     }
 
     @Override
     public int getEndColumnNumber() {
-      // TODO Auto-generated method stub
-      return 0;
+      return -1;
     }
 
     @Override
     public int getEndLineNumber() {
-      // TODO Auto-generated method stub
-      return 0;
+      return -1;
     }
 
     @Override
     public boolean isCatchStmt() {
-      // TODO Auto-generated method stub
       return false;
     }
 
@@ -310,11 +264,6 @@ public abstract class Statement implements Location {
     public boolean equals(Object obj) {
       return obj == this;
     }
-  }
-
-  @Override
-  public String toString() {
-    return rep;
   }
 
   public Method getMethod() {
@@ -415,8 +364,6 @@ public abstract class Statement implements Location {
 
   public abstract boolean isMultiArrayAllocation();
 
-  public abstract boolean isStringAllocation();
-
   public abstract boolean isFieldStore();
 
   public abstract boolean isArrayStore();
@@ -452,29 +399,6 @@ public abstract class Statement implements Location {
 
   public abstract Pair<Val, Integer> getArrayBase();
 
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((method == null) ? 0 : method.hashCode());
-    result = prime * result + ((rep == null) ? 0 : rep.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    Statement other = (Statement) obj;
-    if (method == null) {
-      if (other.method != null) return false;
-    } else if (!method.equals(other.method)) return false;
-    if (rep == null) {
-      return other.rep == null;
-    } else return rep.equals(other.rep);
-  }
-
   public abstract int getStartLineNumber();
 
   public abstract int getStartColumnNumber();
@@ -488,5 +412,23 @@ public abstract class Statement implements Location {
   @Override
   public boolean accepts(Location other) {
     return this.equals(other);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Statement statement = (Statement) o;
+    return Objects.equals(rep, statement.rep) && Objects.equals(method, statement.method);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rep, method);
+  }
+
+  @Override
+  public String toString() {
+    return rep;
   }
 }

--- a/boomerangScope/src/main/java/boomerang/scope/Val.java
+++ b/boomerangScope/src/main/java/boomerang/scope/Val.java
@@ -11,7 +11,10 @@
  */
 package boomerang.scope;
 
+import java.util.Objects;
+
 public abstract class Val {
+
   protected final Method m;
   private final String rep;
   protected final ControlFlowGraph.Edge unbalancedStmt;
@@ -254,33 +257,6 @@ public abstract class Val {
 
   public abstract Type getClassConstantType();
 
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((m == null) ? 0 : m.hashCode());
-    result = prime * result + ((rep == null) ? 0 : rep.hashCode());
-    result = prime * result + ((unbalancedStmt == null) ? 0 : unbalancedStmt.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
-    Val other = (Val) obj;
-    if (m == null) {
-      if (other.m != null) return false;
-    } else if (!m.equals(other.m)) return false;
-    if (rep == null) {
-      if (other.rep != null) return false;
-    } else if (!rep.equals(other.rep)) return false;
-    if (unbalancedStmt == null) {
-      return other.unbalancedStmt == null;
-    } else return unbalancedStmt.equals(other.unbalancedStmt);
-  }
-
   public abstract Val withNewMethod(Method callee);
 
   public Val withSecondVal(Val leftOp) {
@@ -312,4 +288,19 @@ public abstract class Val {
   }
 
   public abstract String getVariableName();
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Val val = (Val) o;
+    return Objects.equals(m, val.m)
+        && Objects.equals(rep, val.rep)
+        && Objects.equals(unbalancedStmt, val.unbalancedStmt);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m, rep, unbalancedStmt);
+  }
 }

--- a/boomerangScope/src/main/java/boomerang/scope/ValWithFalseVariable.java
+++ b/boomerangScope/src/main/java/boomerang/scope/ValWithFalseVariable.java
@@ -1,5 +1,6 @@
 package boomerang.scope;
 
+// TODO May be removed
 public interface ValWithFalseVariable {
   Val getFalseVariable();
 }

--- a/boomerangScope/src/main/java/boomerang/scope/WrappedClass.java
+++ b/boomerangScope/src/main/java/boomerang/scope/WrappedClass.java
@@ -1,10 +1,10 @@
 package boomerang.scope;
 
-import java.util.Set;
+import java.util.Collection;
 
 public interface WrappedClass {
 
-  Set<Method> getMethods();
+  Collection<Method> getMethods();
 
   boolean hasSuperclass();
 
@@ -15,8 +15,4 @@ public interface WrappedClass {
   boolean isApplicationClass();
 
   String getFullyQualifiedName();
-
-  String getName();
-
-  Object getDelegate();
 }

--- a/boomerangScope/src/main/java/boomerang/scope/WrappedClass.java
+++ b/boomerangScope/src/main/java/boomerang/scope/WrappedClass.java
@@ -15,4 +15,6 @@ public interface WrappedClass {
   boolean isApplicationClass();
 
   String getFullyQualifiedName();
+
+  boolean isPhantom();
 }

--- a/idealPDS/src/test/java/test/IDEALTestingFramework.java
+++ b/idealPDS/src/test/java/test/IDEALTestingFramework.java
@@ -160,7 +160,9 @@ public abstract class IDEALTestingFramework extends AbstractTestingFramework {
     for (Statement stmt : m.getStatements()) {
       if (!(stmt.containsInvokeExpr())) continue;
       for (Edge callSite : frameworkScope.getCallGraph().edgesOutOf(stmt)) {
-        parseExpectedQueryResults(callSite.tgt(), queries, visited);
+        if (callSite.tgt().isDefined()) {
+          parseExpectedQueryResults(callSite.tgt(), queries, visited);
+        }
       }
       InvokeExpr invokeExpr = stmt.getInvokeExpr();
       String invocationName = invokeExpr.getMethod().getName();


### PR DESCRIPTION
-Generate missing `equals` and `hashCode` methods
-Add phantom classes and methods: Whenever a class/method does not have a body (e.g. it is a third party class/method and it is not loaded), the call graph/ICFG does not add a corresponding edge. To cover these edges, we add an edge and mark the classes/methods as phantom
-Include the method refs/signatures in a `DeclaredMethod` because currently, we resolve them which contradicts the callgraph and DataFlowScope